### PR TITLE
Added missing integer casting

### DIFF
--- a/python/smqtk/content_description/colordescriptor/colordescriptor.py
+++ b/python/smqtk/content_description/colordescriptor/colordescriptor.py
@@ -593,12 +593,12 @@ class ColorDescriptor_Video (ColorDescriptor_Base):
 
         # If an odd number of jobs, favor descriptor extraction
         if self.PARALLEL:
-            descr_parallel = max(1, math.ceil(self.PARALLEL/2.0))
-            extract_parallel = max(1, math.floor(self.PARALLEL/2.0))
+            descr_parallel = int(max(1, math.ceil(self.PARALLEL/2.0)))
+            extract_parallel = int(max(1, math.floor(self.PARALLEL/2.0)))
         else:
             cpuc = multiprocessing.cpu_count()
-            descr_parallel = max(1, math.ceil(cpuc/2.0))
-            extract_parallel = max(1, math.floor(cpuc/2.0))
+            descr_parallel = int(max(1, math.ceil(cpuc/2.0)))
+            extract_parallel = int(max(1, math.floor(cpuc/2.0)))
 
         # For each video, extract frames and submit colorDescriptor processing
         # jobs for each frame, combining all results into a single matrix for


### PR DESCRIPTION
... when determining component parallelism in video version of ColorDescriptor implementation.

Otherwise the pool construction calls fail (range under the hood requires int).