### PR TITLE
IQR Webapp serve static files

### DIFF
--- a/python/smqtk/data_rep/data_element_abstract.py
+++ b/python/smqtk/data_rep/data_element_abstract.py
@@ -6,6 +6,8 @@ import mimetypes
 import os
 import tempfile
 
+from smqtk.utils import safe_create_dir
+
 
 MIMETYPES = mimetypes.MimeTypes()
 
@@ -48,13 +50,15 @@ class DataElement (object):
 
         :param temp_dir: Optional directory to write temporary file in,
             otherwise we use the platform default temporary files directory.
-        :type temp_dir: None or basestring
+        :type temp_dir: None or str
 
         :return: Path to the temporary file
         :rtype: str
 
         """
         if not hasattr(self, '_temp_filepath') or not self._temp_filepath:
+            if temp_dir:
+                safe_create_dir(temp_dir)
             # noinspection PyAttributeOutsideInit
             fd, self._temp_filepath = tempfile.mkstemp(
                 suffix=MIMETYPES.guess_extension(self.content_type()),

--- a/python/smqtk/data_rep/data_element_abstract.py
+++ b/python/smqtk/data_rep/data_element_abstract.py
@@ -75,9 +75,11 @@ class DataElement (object):
         no temporary files have been generated for this element.
         """
         if hasattr(self, "_temp_filepath"):
-            os.remove(self._temp_filepath)
-            # noinspection PyAttributeOutsideInit
-            self._temp_filepath = None
+            try:
+                if os.path.isfile(self._temp_filepath):
+                    os.remove(self._temp_filepath)
+            finally:
+                del self._temp_filepath
 
     ###
     # Abstract methods

--- a/python/smqtk/data_rep/data_element_impl/file_element.py
+++ b/python/smqtk/data_rep/data_element_impl/file_element.py
@@ -81,13 +81,16 @@ class DataFileElement (DataElement):
 
         :param temp_dir: Optional directory to write temporary file in,
             otherwise we use the platform default temporary files directory.
-        :type temp_dir: None or basestring
+        :type temp_dir: None or str
 
         :return: Path to the temporary file
         :rtype: str
 
         """
-        return self._filepath
+        if temp_dir:
+            return super(DataFileElement, self).write_temp(temp_dir=temp_dir)
+        else:
+            return self._filepath
 
     def clean_temp(self):
         """
@@ -97,7 +100,7 @@ class DataFileElement (DataElement):
         For FileElement instance's this does nothing as the ``write_temp()``
         method doesn't actually write any files.
         """
-        return
+        return super(DataFileElement, self).clean_temp()
 
 
 DATA_ELEMENT_CLASS = DataFileElement

--- a/python/smqtk/data_rep/data_element_impl/file_element.py
+++ b/python/smqtk/data_rep/data_element_impl/file_element.py
@@ -31,6 +31,11 @@ class DataFileElement (DataElement):
         # Cache variables for lazy lading
         self._md5_cache = None
 
+    def __repr__(self):
+        return "%s{uuid: %s, md5: %s, filepath: %s" \
+               % (self.__class__.__name__, self.uuid(), self.md5(),
+                  self._filepath)
+
     def content_type(self):
         """
         :return: Standard type/subtype string for this data element, or None if

--- a/python/smqtk/data_rep/data_set_impl/file_set.py
+++ b/python/smqtk/data_rep/data_set_impl/file_set.py
@@ -112,6 +112,9 @@ class DataFileSet (DataSet):
             self._log.debug("Serializing data elements into: %s",
                             self._root_dir)
             for uuid, de in self._element_map.iteritems():
+                # Remove any temporary files an element may have generated
+                de.clean_temp()
+
                 md5 = de.md5()
                 # Leaving off trailing chunk so that we don't have a single
                 # directory per md5-sum.
@@ -127,6 +130,7 @@ class DataFileSet (DataSet):
                 )
                 with open(output_fname, 'wb') as ofile:
                     cPickle.dump(de, ofile)
+            self._log.debug("Serializing data elements -- Done")
 
     def count(self):
         """

--- a/python/smqtk/web/search_app/modules/iqr/static/js/smqtk.iqr_result.js
+++ b/python/smqtk/web/search_app/modules/iqr/static/js/smqtk.iqr_result.js
@@ -19,6 +19,7 @@ function IqrResult(container, rank, uid, probability) {
     this.probability = probability;
 
     this.image_preview_data = null;
+    this.static_view_link = null;
     this.image_loaded = false;
     this.is_explicit = false;
     // this is 1 if height > width, 0 if otherwise
@@ -219,6 +220,7 @@ IqrResult.prototype.update_view = function (server_update) {
                 else {
                     inst.image_preview_data =
                         'data:image/'+data.ext+';base64,'+ data.data;
+                    inst.static_view_link = data.static_file_link
                     inst.image_loaded = true;
                     inst.is_explicit = inst.e_marked_servereide =
                         data.is_explicit;
@@ -392,7 +394,7 @@ IqrResult.prototype.display_full_image = function () {
             }
         }
         // TODO: Should make this better...
-        //       like open a webpage instead of just opening image data...
-        window.open(this.image_preview_data);
+        //       like open a webpage instead of just opening static data...
+        window.open(this.static_view_link);
     }
 };


### PR DESCRIPTION
+ fix some data element temp file issues

When clicking on the query results in the main window, the window that opens up isn't just the preview data, but a link to a statically-served copy of the actual data as a file server-side.

This won't work with an install of SMQTK, if one manages to do that in the first place, this will probably lead to permission issues (writing to root owned space), but this is supposed to be a demo app anyway.