### PR TITLE
Remove colorDescriptor import error on nosetest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-
 python:
   - "2.7"
 
@@ -38,4 +37,4 @@ install:
 
 # Run tests here
 script:
-  - nosetests --with-doctest python/smqtk/
+  - nosetests --with-doctest --with-coverage --cover-package=smqtk --exclude-dir-file=nose_exclude_dirs.txt python/smqtk

--- a/nose_exclude_dirs.txt
+++ b/nose_exclude_dirs.txt
@@ -1,0 +1,1 @@
+python/smqtk/web/geospace

--- a/python/smqtk/content_description/colordescriptor/colordescriptor.py
+++ b/python/smqtk/content_description/colordescriptor/colordescriptor.py
@@ -21,10 +21,7 @@ from smqtk.utils.video_utils import get_metadata_info
 
 
 # Attempt importing utilities module. If not, flag descriptor as unusable.
-try:
-    from . import utils
-except ImportError:
-    utils = None
+from . import utils
 
 
 # noinspection PyAbstractClass,PyPep8Naming
@@ -86,7 +83,7 @@ class ColorDescriptor_Base (ContentDescriptor):
             return False
 
         # Checking if DescriptorIO is importable
-        if utils is None:
+        if not utils.has_colordescriptor_module():
             log.warn("Could not import DescriptorIO. Make sure that the "
                      "colorDescriptor package is on the PYTHONPATH! See "
                      "smqtk/content_description/colordescriptor/INSTALL.md "

--- a/python/smqtk/content_description/colordescriptor/utils.py
+++ b/python/smqtk/content_description/colordescriptor/utils.py
@@ -20,8 +20,16 @@ except ImportError:
         from colorDescriptor import DescriptorIO
     except ImportError:
         DescriptorIO = None
-        raise ImportError("Cannot find the DescriptorIO module provided by "
-                          "ColorDescriptor. Read the README for dependencies!")
+
+
+def has_colordescriptor_module():
+    """
+    :return: Boolean describing whether the required colorDescriptor module was
+        found or not. If not found, the base descriptor functionality does not
+        exist.
+    :rtype: bool
+    """
+    return DescriptorIO is not None
 
 
 def generate_descriptors(cd_exe, img_filepath, descriptor_type,
@@ -41,6 +49,8 @@ def generate_descriptors(cd_exe, img_filepath, descriptor_type,
     Matrices are saved in numpy binary format (.npy). ``numpy.load`` function
     should be used to load matrices back in.
 
+    :raises ImportError: The required python module for colorDescriptor IO is
+        not available.
     :raises RuntimeError: Failed to generate output files or matrices for the '
         given input.
 
@@ -77,6 +87,10 @@ def generate_descriptors(cd_exe, img_filepath, descriptor_type,
     :rtype: ((int, int), (int, int))
 
     """
+    if not has_colordescriptor_module():
+        raise ImportError("Cannot find the DescriptorIO module provided by "
+                          "ColorDescriptor. Read the README for dependencies!")
+
     log = logging.getLogger("ColorDescriptor::generate_descriptors{%s,%s}"
                             % (descriptor_type, osp.basename(img_filepath)))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
+coverage
 flask
 flask-basicauth
 flask-login
-gevent
 imageio
 nose
+nose-exclude
 Pillow
 pymongo
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ coverage
 flask
 flask-basicauth
 flask-login
+gevent
 imageio
 nose
 nose-exclude


### PR DESCRIPTION
Being an optional dependency, an exception shouldn't be emitted by merely importing the SMQTK module, but informed at runtime that its not available.

Addresses issue #72 