### PR TITLE
Gracefully handle data of invalid content type for a descriptor

### DIFF
--- a/python/smqtk/content_description/colordescriptor/colordescriptor.py
+++ b/python/smqtk/content_description/colordescriptor/colordescriptor.py
@@ -382,6 +382,8 @@ class ColorDescriptor_Base (ContentDescriptor):
         :rtype: numpy.ndarray
 
         """
+        super(ColorDescriptor_Base, self).compute_descriptor(data)
+
         checkpoint_filepath = self._get_checkpoint_feature_file(data)
         if osp.isfile(checkpoint_filepath):
             return numpy.load(checkpoint_filepath)

--- a/python/smqtk/web/descriptor_service/server.py
+++ b/python/smqtk/web/descriptor_service/server.py
@@ -36,6 +36,9 @@ class DescriptorServiceServer (flask.Flask):
 
         /<descriptor_type>/<uri>[?...]
 
+    See the docstring for the ``compute_descriptor()`` method for complete rules
+    on how to form a calling URL.
+
     Computes the requested descriptor for the given file and returns that via
     a JSON structure.
 
@@ -188,14 +191,20 @@ class DescriptorServiceServer (flask.Flask):
                     #: :type: smqtk.content_description.ContentDescriptor
                     d = descriptor_cache[descriptor_label]
                 with SimpleTimer("Computing descriptor...", self.log.debug):
-                    descriptor = d.compute_descriptor(de)
-                    message = "Descriptor computed of type '%s'" \
-                              % descriptor_label
+                    try:
+                        descriptor = d.compute_descriptor(de).tolist()
+                        message = "Descriptor computed of type '%s'" \
+                                  % descriptor_label
+                    except ValueError, ex:
+                        success = False
+                        message = "Descriptor '%s' had an issue with the input " \
+                                  "data: %s" \
+                                  % (descriptor_label, str(ex))
 
             return flask.jsonify({
                 "success": success,
                 "message": message,
-                "descriptor": descriptor.tolist(),
+                "descriptor": descriptor,
                 "reference_uri": uri
             })
 


### PR DESCRIPTION
Instead of just returning a "INTERNAL SERVER ERROR" when a descriptor
type is given an data type it can't handle, returns a JSON message with
False success and a message that describes the issue.

Also added missing super-call to colordescriptor `compute_descriptor()` implementation.