### PR TITLE
Use relative paths

### DIFF
--- a/etc/system_config.json
+++ b/etc/system_config.json
@@ -11,14 +11,16 @@
         "example_image": {
             "type": "DataFileSet",
             "init": {
-                "root_directory": "/Users/purg/dev/smqtk/source/data/FileDataSets/example_image/data",
+                // DataFileSet implementation interprets relative paths to the
+                // DATA_DIR variable as configured in smqtk_config module.
+                "root_directory": "FileDataSets/example_image/data",
                 "md5_chunk": 8
             }
         },
         "example_video": {
             "type": "DataFileSet",
             "init": {
-                "root_directory": "/Users/purg/dev/smqtk/source/data/FileDataSets/example_video/data",
+                "root_directory": "FileDataSets/example_video/data",
                 "md5_chunk": 8
             }
         }
@@ -32,6 +34,9 @@
         "MemoryDescriptorFactory": {
             "type": "DescriptorMemoryElement",
             "init": {
+                // No initialization parameters for this factory, simply stores
+                // vectors in local RAM.
+                //
                 // Other descriptor implementation construction parameters,
                 // i.e. parameters other than the type string and UUID, should
                 // be set here.
@@ -42,7 +47,10 @@
         "LocalDiskFactory": {
             "type": "DescriptorFileElement",
             "init": {
-                "save_dir": "/Users/purg/dev/smqtk/source/work/LocalDescriptors"
+                // DescriptorFileElement implementation interprets relative
+                // paths to the WORK_DIR variable as configured in smqtk_config
+                // module.
+                "save_dir": "LocalDescriptors"
             }
         }
     },

--- a/python/smqtk/content_description/__init__.py
+++ b/python/smqtk/content_description/__init__.py
@@ -77,8 +77,8 @@ class ContentDescriptor (object):
         Generate this feature detector's data-model given a file ingest. This
         saves the generated model to the currently configured data directory.
 
-        This method does nothing if there is already a model generated or if
-        this descriptor does not generate a model.
+        This method should do nothing if there is already a model generated or
+        if this descriptor does not generate a model.
 
         This abstract super method should be invoked for common error checking.
 

--- a/python/smqtk/content_description/colordescriptor/colordescriptor.py
+++ b/python/smqtk/content_description/colordescriptor/colordescriptor.py
@@ -114,7 +114,7 @@ class ColorDescriptor_Base (ContentDescriptor):
         :type kmeans_k: int
 
         :param flann_target_precision: Target precision percent to tune index
-            for. Default is 0.90 (90% accuracy). For some codebooks, if this is
+            for. Default is 0.95 (95% accuracy). For some codebooks, if this is
             too close to 1.0, the FLANN library may non-deterministically
             overflow, causing an infinite loop requiring a SIGKILL to stop.
         :type flann_target_precision: float

--- a/python/smqtk/data_rep/data_element_impl/file_element.py
+++ b/python/smqtk/data_rep/data_element_impl/file_element.py
@@ -16,7 +16,9 @@ class DataFileElement (DataElement):
         """
         Create a new FileElement.
 
-        :param filepath: Path to the file to wrap.
+        :param filepath: Path to the file to wrap.  If relative, it is
+            interpreted as relative to the WORK_DIR path set in the
+            `smqtk_config` module.
         :type filepath: str
 
         """

--- a/python/smqtk/data_rep/data_element_impl/file_element.py
+++ b/python/smqtk/data_rep/data_element_impl/file_element.py
@@ -3,6 +3,7 @@ __author__ = 'purg'
 import mimetypes
 import os.path as osp
 
+from smqtk_config import WORK_DIR
 from smqtk.data_rep import DataElement
 
 
@@ -21,7 +22,8 @@ class DataFileElement (DataElement):
         """
         super(DataFileElement, self).__init__()
 
-        self._filepath = osp.abspath(osp.expanduser(filepath))
+        self._filepath = osp.abspath(osp.join(WORK_DIR,
+                                              osp.expanduser(filepath)))
         self._content_type = mimetypes.guess_type(filepath)[0]
 
     def __repr__(self):

--- a/python/smqtk/data_rep/data_set_impl/file_set.py
+++ b/python/smqtk/data_rep/data_set_impl/file_set.py
@@ -38,7 +38,9 @@ class DataFileSet (DataSet):
         """
         Initialize a new or existing file set from a root directory.
 
-        :param root_directory: Directory that this file set is based in.
+        :param root_directory: Directory that this file set is based in. If
+            relative, it is interpreted as relative to the DATA_DIR path set
+            in the `smqtk_config` module.
         :type root_directory: str
 
         :param md5_chunk: Number of segments to split data element MD5 sum into

--- a/python/smqtk/data_rep/data_set_impl/file_set.py
+++ b/python/smqtk/data_rep/data_set_impl/file_set.py
@@ -8,6 +8,8 @@ import os
 
 import re
 
+from smqtk_config import DATA_DIR
+
 from smqtk.data_rep import DataElement, DataSet
 from smqtk.utils import safe_create_dir
 from smqtk.utils.file_utils import iter_directory_files
@@ -44,7 +46,12 @@ class DataFileSet (DataSet):
         :type md5_chunk: int
 
         """
-        self._root_dir = os.path.abspath(root_directory)
+        self._root_dir = os.path.abspath(
+            os.path.join(
+                DATA_DIR,
+                os.path.expanduser(root_directory)
+            )
+        )
         self._md5_chunk = md5_chunk
 
         self._log.debug("Initializing FileSet under root dir: %s",

--- a/python/smqtk/utils/__init__.py
+++ b/python/smqtk/utils/__init__.py
@@ -16,8 +16,8 @@ def safe_create_dir(d):
     :param d: Directory filepath to create
     :type d: str
 
-    :return: The directory that was create, i.e. the directory that was passed
-        in (absolute form).
+    :return: The directory that was created, i.e. the directory that was passed
+        (in absolute form).
     :rtype: str
 
     """


### PR DESCRIPTION
Allow configuration of data file-sets and data file-element (in factory config) to take relative paths.