### PR TITLE
Add travis ci image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 SMQTK
 =====
 ![Build Status](https://travis-ci.org/Kitware/SMQTK.svg?branch=master)
+
 Social Multimedia Query ToolKit aims to provide a simple and easy to use interface for content descriptor generation for machine learning, content similarity computation (kNN implementations), and ranking for online Iterative Query Refinement (IQR) adjudications.
 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 SMQTK
 =====
+![Build Status](https://travis-ci.org/Kitware/SMQTK.svg?branch=master)
 Social Multimedia Query ToolKit aims to provide a simple and easy to use interface for content descriptor generation for machine learning, content similarity computation (kNN implementations), and ranking for online Iterative Query Refinement (IQR) adjudications.
 
 


### PR DESCRIPTION
Adds Travis CI status badge to README.md file for graphical display when markdown is rendered (with access to the internet, i.e. GitHub).