### PR TITLE
Added another exeption for silly jpeg mimetypes

### DIFF
--- a/python/smqtk/data_rep/data_element_abstract.py
+++ b/python/smqtk/data_rep/data_element_abstract.py
@@ -83,7 +83,7 @@ class DataElement (object):
                 safe_create_dir(d)
             ext = MIMETYPES.guess_extension(self.content_type())
             # Exceptions because mimetypes is apparently REALLY OLD
-            if ext == '.jpe':
+            if ext in {'.jpe', '.jfif'}:
                 ext = '.jpg'
             fd, fp = tempfile.mkstemp(
                 suffix=ext,


### PR DESCRIPTION
Because its still a thing where non-standard jpeg extensions can get
priority in python's mimetypes module