### PR TITLE
Better itq nn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ addons:
       # basics
       - linux-headers-3.13.0-40-generic
       - build-essential
-      - gcc
       # For building things
       - cmake
       # for python module gmpy2
       - libgmp-dev
+      - libmpc2
       - libmpc-dev
       - libmpfr-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       # basics
       - linux-headers-3.13.0-40-generic
       - build-essential
+      - gcc-48
       # For building things
       - cmake
       # for python module gmpy2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,16 @@ addons:
       - cmake
       # for python module gmpy2
       - libgmp-dev
-      - libmpc2
-      # - libmpc-dev
       - libmpfr-dev
 
 # Environment setup
 before_install:
+  # Added Local Environment Update
+  - export LOCAL_ROOT=${HOME}/.local
+  - export CPATH=${LOCAL_ROOT}/include:${CPATH}
+  - export PATH=${LOCAL_ROOT}/bin:$PATH
+  - export LD_LIBRARY_PATH=${LOCAL_ROOT}/lib64:${LOCAL_ROOT}/lib:$LD_LIBRARY_PATH
+  - mkdir ${LOCAL_ROOT}
   # Setup local conda python
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -31,12 +35,21 @@ before_install:
   - conda info -a
   - conda create -q -n smqtk-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION
   - source activate smqtk-$TRAVIS_PYTHON_VERSION
+  # Required gmpy2 deps (taken from scipy .travis.yml)
+  - export MPC_VERSION=1.0.3
+  - wget ftp://ftp.gnu.org/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
+  - tar xzf mpc-${MPC_VERSION}.tar.gz
+  - pushd mpc-${MPC_VERSION}
+  - ./configure --prefix=${LOCAL_ROOT}
+  - make
+  - make install
+  - popd
 
 # "Install" of SMQTK + immediate deps
 install:
   - conda install -q --file requirements.conda.txt
   - pip install -qr requirements.pip.txt
-  - pip install gmpy2
+  # - pip install gmpy2
 
   # Build components of SMQTK
   - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ sudo: false
 addons:
   apt:
     packages:
+      # basics
+      - linux-headers-generic
+      - build-essential
+      # For building things
       - cmake
       # for python module gmpy2
       - libgmp-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
 install:
   - conda install -q --file requirements.conda.txt
   - pip install -qr requirements.pip.txt
-  # - pip install gmpy2
+  - pip install gmpy2
 
   # Build components of SMQTK
   - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
 install:
   - conda install -q --file requirements.conda.txt
   - pip install -qr requirements.pip.txt
+  - pip install gmpy2
 
   # Build components of SMQTK
   - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       # basics
       - linux-headers-3.13.0-40-generic
       - build-essential
-      - gcc-48
+      - gcc
       # For building things
       - cmake
       # for python module gmpy2

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   # Added Local Environment Update
   - export LOCAL_ROOT=${HOME}/.local
   - export CPATH=${LOCAL_ROOT}/include:${CPATH}
-  - export LDFLAGS="${LDFLAGS} -L ${LOCAL_ROOT}/lib"
+  - export LDFLAGS="${LDFLAGS} -L${LOCAL_ROOT}/lib"
   - export PATH=${LOCAL_ROOT}/bin:$PATH
   - export LD_LIBRARY_PATH=${LOCAL_ROOT}/lib:$LD_LIBRARY_PATH
   - mkdir ${LOCAL_ROOT}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
       # for python module gmpy2
       - libgmp-dev
       - libmpc2
-      - libmpc-dev
+      # - libmpc-dev
       - libmpfr-dev
 
 # Environment setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ addons:
   apt:
     packages:
       - cmake
+      # for python module gmpy2
+      - libgmp-dev
+      - libmpc-dev
+      - libmpfr-dev
 
 # Environment setup
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
   apt:
     packages:
       # basics
-      - linux-headers-generic
+      - linux-headers-3.13.0-40-generic
       - build-essential
       # For building things
       - cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ before_install:
   # Added Local Environment Update
   - export LOCAL_ROOT=${HOME}/.local
   - export CPATH=${LOCAL_ROOT}/include:${CPATH}
+  - export LDFLAGS="${LDFLAGS} -L ${LOCAL_ROOT}/lib"
   - export PATH=${LOCAL_ROOT}/bin:$PATH
-  - export LD_LIBRARY_PATH=${LOCAL_ROOT}/lib64:${LOCAL_ROOT}/lib:$LD_LIBRARY_PATH
+  - export LD_LIBRARY_PATH=${LOCAL_ROOT}/lib:$LD_LIBRARY_PATH
   - mkdir ${LOCAL_ROOT}
   # Setup local conda python
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -36,12 +37,12 @@ before_install:
   - conda create -q -n smqtk-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION
   - source activate smqtk-$TRAVIS_PYTHON_VERSION
   # Required gmpy2 deps (taken from scipy .travis.yml)
-  - export MPC_VERSION=1.0.3
+  - export MPC_VERSION=1.0.2
   - wget ftp://ftp.gnu.org/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
   - tar xzf mpc-${MPC_VERSION}.tar.gz
   - pushd mpc-${MPC_VERSION}
   - ./configure --prefix=${LOCAL_ROOT}
-  - make
+  - make -j2
   - make install
   - popd
 

--- a/python/smqtk/similarity_index/flann.py
+++ b/python/smqtk/similarity_index/flann.py
@@ -309,6 +309,16 @@ class FlannSimilarity (SimilarityIndex):
         self._flann.load_index(osp.join(dir_path, self._sf_flann_index),
                                pts_array)
 
+        # initialize index cache
+        self._pid = multiprocessing.current_process().pid
+        safe_create_dir(self._temp_dir)
+        fd, self._flann_index_cache = tempfile.mkstemp(".flann",
+                                                       dir=self._temp_dir)
+        os.close(fd)
+        self._log.debug("saving loaded index to cache file: %s",
+                        self._flann_index_cache)
+        self._flann.save_index(self._flann_index_cache)
+
     def nn(self, d, n=1):
         """
         Return the nearest `N` neighbors to the given descriptor element.

--- a/python/smqtk/similarity_index/lsh/code_index/__init__.py
+++ b/python/smqtk/similarity_index/lsh/code_index/__init__.py
@@ -47,7 +47,7 @@ class CodeIndex (object):
     @abc.abstractmethod
     def codes(self):
         """
-        :return: Set of codes integers currently used in this code index.
+        :return: Set of code integers currently used in this code index.
         :rtype: set[int]
         """
         return

--- a/python/smqtk/similarity_index/lsh/code_index/__init__.py
+++ b/python/smqtk/similarity_index/lsh/code_index/__init__.py
@@ -45,6 +45,14 @@ class CodeIndex (object):
         return
 
     @abc.abstractmethod
+    def codes(self):
+        """
+        :return: Set of codes integers currently used in this code index.
+        :rtype: set[int]
+        """
+        return
+
+    @abc.abstractmethod
     def add_descriptor(self, code, descriptor):
         """
         Add a descriptor to this index given a matching small-code.

--- a/python/smqtk/similarity_index/lsh/code_index/memory.py
+++ b/python/smqtk/similarity_index/lsh/code_index/memory.py
@@ -31,7 +31,7 @@ class MemoryCodeIndex (CodeIndex):
 
     def codes(self):
         """
-        :return: Set of codes integers currently used in this code index.
+        :return: Set of code integers currently used in this code index.
         :rtype: set[int]
         """
         return set(self._table)

--- a/python/smqtk/similarity_index/lsh/code_index/memory.py
+++ b/python/smqtk/similarity_index/lsh/code_index/memory.py
@@ -29,6 +29,13 @@ class MemoryCodeIndex (CodeIndex):
         """
         return self._num_descr
 
+    def codes(self):
+        """
+        :return: Set of codes integers currently used in this code index.
+        :rtype: set[int]
+        """
+        return set(self._table)
+
     def add_descriptor(self, code, descriptor):
         """
         Add a descriptor to this index given a matching small-code

--- a/python/smqtk/similarity_index/lsh/code_index/solr_index.py
+++ b/python/smqtk/similarity_index/lsh/code_index/solr_index.py
@@ -135,6 +135,17 @@ class SolrCodeIndex (CodeIndex):
                              self.descriptor_field))
                    .numFound)
 
+    def codes(self):
+        """
+        :return: Set of codes integers currently used in this code index.
+        :rtype: set[int]
+        """
+        r = self.solr.select("%s:%s" % (self.idx_uuid_field, self.uuid),
+                             rows=0,
+                             facet='true', facet_field=self.code_field)
+        val2count = r.facet_counts['facet_fields'][self.code_field]
+        return set(int(k) for k in val2count)
+
     def _doc_for_code_descr(self, code, descr):
         """
         Generate standard identifying document base for the given

--- a/python/smqtk/similarity_index/lsh/code_index/solr_index.py
+++ b/python/smqtk/similarity_index/lsh/code_index/solr_index.py
@@ -137,7 +137,7 @@ class SolrCodeIndex (CodeIndex):
 
     def codes(self):
         """
-        :return: Set of codes integers currently used in this code index.
+        :return: Set of code integers currently used in this code index.
         :rtype: set[int]
         """
         r = self.solr.select("%s:%s" % (self.idx_uuid_field, self.uuid),

--- a/python/smqtk/similarity_index/lsh/code_index/solr_index.py
+++ b/python/smqtk/similarity_index/lsh/code_index/solr_index.py
@@ -86,6 +86,7 @@ class SolrCodeIndex (CodeIndex):
 
         self.commit_on_add = commit_on_add
         self.max_boolean_clauses = max_boolean_clauses
+        assert self.max_boolean_clauses >= 2, "Need more clauses"
 
         self.solr = solr.Solr(solr_conn_addr, persistent=persistent_connection,
                               timeout=timeout,

--- a/python/smqtk/similarity_index/lsh/itq.py
+++ b/python/smqtk/similarity_index/lsh/itq.py
@@ -290,6 +290,12 @@ class ITQSimilarityIndex (SimilarityIndex):
                 (bit_utils.bit_vector_to_int(c[i]), descr_cache[i])
                 for i in xrange(c.shape[0])
             )
+        # NOTE: If a sub-sampling effect is implemented above, this will have to
+        #       change to querying for descriptor vectors individually since the
+        #       ``c`` matrix will not encode all descriptors at that point. This
+        #       will be slower unless we think of something else. Could probably
+        #       map the small code generation function by bringing it outside of
+        #       the class.
 
     def save_index(self, dir_path):
         """

--- a/python/smqtk/utils/bit_utils.py
+++ b/python/smqtk/utils/bit_utils.py
@@ -47,6 +47,33 @@ def iter_perms(l, n):
         yield s
 
 
+def neighbor_codes(b, c, d):
+    """
+    Iterate through integers of bit length ``b``, where ``b`` is the number
+    of bits, that are ``d`` hamming distance away from query code ``c``.
+
+    This will yield a number of elements equal to ``nCr(b, d)``.
+
+    We expect ``d`` to be the integer hamming distance,
+    e.g. h(001101, 100101) == 2, not 0.333.
+
+    :param b: integer bit length
+    :param b: int
+
+    :param c: Query small-code integer
+    :type c: int
+
+    :param d: Integer hamming distance
+    :type d: int
+
+    """
+    if not d:
+        yield c
+    else:
+        for fltr in iter_perms(b, d):
+            yield c ^ fltr
+
+
 def bit_vector_to_int(v):
     """
     Transform a numpy vector representing a sequence of binary bits [0 | >0]

--- a/python/smqtk/utils/bit_utils.py
+++ b/python/smqtk/utils/bit_utils.py
@@ -87,7 +87,7 @@ def bit_vector_to_int(v):
     :return: Integer equivalent
 
     """
-    c = 0
+    c = 0L
     for b in v:
-        c = (c << 1) | b
+        c = (c * 2L) + int(b)
     return c

--- a/python/smqtk/utils/distance_functions.py
+++ b/python/smqtk/utils/distance_functions.py
@@ -7,6 +7,7 @@ Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
 
 """
 
+import gmpy2
 import numpy
 
 
@@ -134,3 +135,20 @@ def cosine_similarity(i, j):
 
     # speed optimization, numpy.linalg.norm can be a bottleneck
     return numpy.dot(i, j) / (numpy.sqrt(i.dot(i)) * numpy.sqrt(j.dot(j)))
+
+
+def hamming_distance(i, j):
+    """
+    Return the hamming distance between the two given integers, or the number of
+    places where the bits differ.
+
+    :param i: First integer.
+    :type i: int
+    :param j: Second integer.
+    :type j: int
+
+    :return: Integer hamming distance between the two values.
+    :rtype: int
+
+    """
+    return gmpy2.popcount(i ^ j)

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,4 +1,5 @@
 flask-basicauth
+gmpy2
 imageio
 nose-exclude
 solrpy

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,5 +1,4 @@
 flask-basicauth
-gmpy2
 imageio
 nose-exclude
 solrpy


### PR DESCRIPTION
Two primary fixes:
* modified ITQ index's ``nn`` method to not use bit-vector permutation, which is infeasible for large bit vector lengths, to a hamming distance computation and sort using heap-based priority queue.
* Fixed bug with bit-vector-to-int transformation function. Had an issue where the numpy int type was poluting the python int type and causing overflow issues instead of int->long extension. This was exposed when experimenting with larger bit vector sizes.

The `nn` function could probably be improved further by using a data structure that is initialized at index creation tile which allows for distance-based neighbor querying. Attempted the use of a VP-tree (https://en.wikipedia.org/wiki/Vantage-point_tree) using the python implementation that is linked on the wiki page, but its proved infeasible for large index sizes (1,000,000+). Using GMPY2, hamming distance computation and heap construction/retrieval proved feasible for the 1-10 million range, but increases in time cost for higher numbers of codes in the index.