### PR TITLE
Fix DescriptorMemoryElement pickling issue

### DIFF
--- a/python/smqtk/data_rep/descriptor_element_abstract.py
+++ b/python/smqtk/data_rep/descriptor_element_abstract.py
@@ -70,6 +70,9 @@ class DescriptorElement (Configurable):
             a configuration.
         :type config_dict: dict
 
+        :return: Constructed instance from the provided config.
+        :rtype: DescriptorElement
+
         """
         return cls(type_str, uuid, **config_dict)
 

--- a/python/smqtk/data_rep/descriptor_element_factory.py
+++ b/python/smqtk/data_rep/descriptor_element_factory.py
@@ -14,10 +14,37 @@ class DescriptorElementFactory (Configurable):
 
     @classmethod
     def default_config(cls):
+        """
+        Generate and return a default configuration dictionary for this class.
+        This will be primarily used for generating what the configuration
+        dictionary would look like for this class without instantiating it.
+
+        It is not be guaranteed that the configuration dictionary returned
+        from this method is valid for construction of an instance of this class.
+
+        :return: Default configuration dictionary for the class.
+        :rtype: dict
+
+        """
         return make_config(get_descriptor_element_impls)
 
     @classmethod
     def from_config(cls, config_dict):
+        """
+        Instantiate a new instance of this class given the configuration
+        JSON-compliant dictionary encapsulating initialization arguments.
+
+        This method should not be called via super unless and instance of the
+        class is desired.
+
+        :param config_dict: JSON compliant dictionary encapsulating
+            a configuration.
+        :type config_dict: dict
+
+        :return: Constructed instance from the provided config.
+        :rtype: DescriptorElementFactory
+
+        """
         return DescriptorElementFactory(
             get_descriptor_element_impls()[config_dict['type']],
             config_dict[config_dict['type']]

--- a/python/smqtk/data_rep/descriptor_element_impl/local_elements.py
+++ b/python/smqtk/data_rep/descriptor_element_impl/local_elements.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import numpy
 import os
 import os.path as osp
@@ -18,6 +19,19 @@ class DescriptorMemoryElement (DescriptorElement):
 
     # In-memory cache of descriptor vectors
     MEMORY_CACHE = {}
+    MEMORY_CACHE_LOCK = multiprocessing.RLock()
+
+    def __getstate__(self):
+        return self.type(), self.uuid(), self.vector(),
+
+    def __setstate__(self, state):
+        self._type_label = state[0]
+        self._uuid = state[1]
+        with self.MEMORY_CACHE_LOCK:
+            self.MEMORY_CACHE[self._get_cache_index()] = state[2]
+
+    def _get_cache_index(self):
+        return self.type(), self.uuid()
 
     def get_config(self):
         """
@@ -32,7 +46,7 @@ class DescriptorMemoryElement (DescriptorElement):
             stored.
         :rtype: bool
         """
-        return self.uuid() in DescriptorMemoryElement.MEMORY_CACHE
+        return self._get_cache_index() in self.MEMORY_CACHE
 
     def vector(self):
         """
@@ -40,7 +54,7 @@ class DescriptorMemoryElement (DescriptorElement):
             None of there is no vector stored in this container.
         :rtype: numpy.core.multiarray.ndarray or None
         """
-        return DescriptorMemoryElement.MEMORY_CACHE.get(self.uuid(), None)
+        return self.MEMORY_CACHE.get(self._get_cache_index(), None)
 
     def set_vector(self, new_vec):
         """
@@ -53,7 +67,7 @@ class DescriptorMemoryElement (DescriptorElement):
         :type new_vec: numpy.core.multiarray.ndarray
 
         """
-        DescriptorMemoryElement.MEMORY_CACHE[self.uuid()] = new_vec
+        self.MEMORY_CACHE[self._get_cache_index()] = new_vec
 
 
 class DescriptorFileElement (DescriptorElement):

--- a/python/smqtk/data_rep/descriptor_element_impl/local_elements.py
+++ b/python/smqtk/data_rep/descriptor_element_impl/local_elements.py
@@ -46,7 +46,8 @@ class DescriptorMemoryElement (DescriptorElement):
             stored.
         :rtype: bool
         """
-        return self._get_cache_index() in self.MEMORY_CACHE
+        with self.MEMORY_CACHE_LOCK:
+            return self._get_cache_index() in self.MEMORY_CACHE
 
     def vector(self):
         """
@@ -54,7 +55,8 @@ class DescriptorMemoryElement (DescriptorElement):
             None of there is no vector stored in this container.
         :rtype: numpy.core.multiarray.ndarray or None
         """
-        return self.MEMORY_CACHE.get(self._get_cache_index(), None)
+        with self.MEMORY_CACHE_LOCK:
+            return self.MEMORY_CACHE.get(self._get_cache_index(), None)
 
     def set_vector(self, new_vec):
         """
@@ -67,7 +69,8 @@ class DescriptorMemoryElement (DescriptorElement):
         :type new_vec: numpy.core.multiarray.ndarray
 
         """
-        self.MEMORY_CACHE[self._get_cache_index()] = new_vec
+        with self.MEMORY_CACHE_LOCK:
+            self.MEMORY_CACHE[self._get_cache_index()] = new_vec
 
 
 class DescriptorFileElement (DescriptorElement):

--- a/python/smqtk/tests/data_rep/DescriptorElement/test_DescriptorMemoryElement.py
+++ b/python/smqtk/tests/data_rep/DescriptorElement/test_DescriptorMemoryElement.py
@@ -1,5 +1,8 @@
-import nose.tools as ntools
+import cPickle
 import unittest
+
+import nose.tools as ntools
+import numpy
 
 from smqtk.data_rep.descriptor_element_impl.local_elements import DescriptorMemoryElement
 
@@ -22,3 +25,38 @@ class TestDescriptorMemoryElement (unittest.TestCase):
         inst2 = DescriptorMemoryElement.from_config(inst1.get_config(),
                                                     'test', 'a')
         ntools.assert_equal(inst1, inst2)
+
+    def test_pickle_dump_load(self):
+        # Wipe current cache
+        DescriptorMemoryElement.MEMORY_CACHE = {}
+
+        # Make a couple descriptors
+        v1 = numpy.array([1, 2, 3])
+        d1 = DescriptorMemoryElement('test', 0)
+        d1.set_vector(v1)
+
+        v2 = numpy.array([4, 5, 6])
+        d2 = DescriptorMemoryElement('test', 1)
+        d2.set_vector(v2)
+
+        ntools.assert_in(('test', 0), DescriptorMemoryElement.MEMORY_CACHE)
+        ntools.assert_in(('test', 1), DescriptorMemoryElement.MEMORY_CACHE)
+
+        d1_s = cPickle.dumps(d1)
+        d2_s = cPickle.dumps(d2)
+
+        # Wipe cache again
+        DescriptorMemoryElement.MEMORY_CACHE = {}
+        ntools.assert_not_in(('test', 0), DescriptorMemoryElement.MEMORY_CACHE)
+        ntools.assert_not_in(('test', 1), DescriptorMemoryElement.MEMORY_CACHE)
+
+        # Attempt reconstitution
+        d1_r = cPickle.loads(d1_s)
+        d2_r = cPickle.loads(d2_s)
+
+        numpy.testing.assert_array_equal(v1, d1_r.vector())
+        numpy.testing.assert_array_equal(v2, d2_r.vector())
+
+        # Cache should now have those entries back in it
+        ntools.assert_in(('test', 0), DescriptorMemoryElement.MEMORY_CACHE)
+        ntools.assert_in(('test', 1), DescriptorMemoryElement.MEMORY_CACHE)


### PR DESCRIPTION
Because the DescriptorMemoryElement uses a class variable to cache data in, when pickling an instance, this cache didn't get drawn into it, so loading the pickled class in a different process or at a different time yielded the element to think it didn't have an associated vector, defeating the point of having pickled it in the first place.

Now, we implement custom state get/set methods that encode an element's numpy vector if one was set on it, restoring it to the cache when loaded.