### PR TITLE
Remove gmpy2 dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ addons:
       - build-essential
       # For building things
       - cmake
-      # for python module gmpy2
-      - libgmp-dev
-      - libmpfr-dev
 
 # Environment setup
 before_install:
@@ -36,15 +33,6 @@ before_install:
   - conda info -a
   - conda create -q -n smqtk-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION
   - source activate smqtk-$TRAVIS_PYTHON_VERSION
-  # Required gmpy2 deps (taken from scipy .travis.yml)
-  - export MPC_VERSION=1.0.2
-  - wget ftp://ftp.gnu.org/gnu/mpc/mpc-${MPC_VERSION}.tar.gz
-  - tar xzf mpc-${MPC_VERSION}.tar.gz
-  - pushd mpc-${MPC_VERSION}
-  - ./configure --prefix=${LOCAL_ROOT}
-  - make -j2
-  - make install
-  - popd
 
 # "Install" of SMQTK + immediate deps
 install:

--- a/python/smqtk/tests/utils/test_distance_functions.py
+++ b/python/smqtk/tests/utils/test_distance_functions.py
@@ -1,3 +1,4 @@
+import random
 import unittest
 
 import nose.tools as ntools
@@ -7,6 +8,10 @@ from smqtk.utils import distance_functions as df
 
 
 __author__ = 'purg'
+
+
+def gen(n):
+    return random.randint(0, 2**n-1)
 
 
 class TestHistogramIntersectionDistance (unittest.TestCase):
@@ -78,3 +83,25 @@ class TestHistogramIntersectionDistance (unittest.TestCase):
 
         ntools.assert_raises(ValueError, df.histogram_intersection_distance,
                              self.m1, self.m2)
+
+
+class TestHammingDistance (unittest.TestCase):
+
+    def test_hd_0(self):
+        ntools.assert_equal(df.hamming_distance(0, 0), 0)
+
+    def test_rand(self):
+        n = 64
+        for i in xrange(1000):
+            a = gen(n)
+            b = gen(n)
+            actual = bin(a^b).count('1')
+            ntools.assert_equal(df.hamming_distance(a, b), actual)
+
+    def test_rand_large(self):
+        n = 1024
+        for i in xrange(1000):
+            a = gen(n)
+            b = gen(n)
+            actual = bin(a^b).count('1')
+            ntools.assert_equal(df.hamming_distance(a, b), actual)

--- a/python/smqtk/utils/distance_functions.py
+++ b/python/smqtk/utils/distance_functions.py
@@ -7,7 +7,6 @@ Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
 
 """
 
-import gmpy2
 import numpy as np
 
 
@@ -137,4 +136,4 @@ def hamming_distance(i, j):
     :rtype: int
 
     """
-    return gmpy2.popcount(i ^ j)
+    return bin(i ^ j).count('1')

--- a/python/smqtk/utils/distance_functions.py
+++ b/python/smqtk/utils/distance_functions.py
@@ -7,6 +7,7 @@ Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
 
 """
 
+from math import log, ceil
 import numpy as np
 
 
@@ -138,3 +139,31 @@ def hamming_distance(i, j):
     """
     # TODO: Find something better than this.
     return bin(i ^ j).count('1')
+
+
+def popcount(v):
+    """
+    Pure python popcount algorithm adapted implementation at:
+    see: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+    """
+    if not v:
+        return 0
+
+    # T is the number of bits used to represent v to the nearest power of 2
+    tp = max(8, int(2**ceil(log(v.bit_length()) / log(2))))
+    t = 2**tp-1
+    b = tp // 8
+
+    # bit-length constrained
+    h55 = t//3
+    h33 = t//15*3
+    h0f = t//255*15
+    h01 = t//255
+
+    v = v - ((v >> 1) & h55)
+    v = (v & h33) + ((v >> 2) & h33)
+    v = (v + (v >> 4)) & h0f
+    # Need the extra ``& t`` after the multiplication in order to simulate bit
+    # truncation as if v were only a tp-bit integer
+    # Magic 8 represents bits ina byte
+    return ((v * h01) & t) >> ((b-1) * 8)

--- a/python/smqtk/utils/distance_functions.py
+++ b/python/smqtk/utils/distance_functions.py
@@ -136,4 +136,5 @@ def hamming_distance(i, j):
     :rtype: int
 
     """
+    # TODO: Find something better than this.
     return bin(i ^ j).count('1')

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,5 +1,4 @@
 flask-basicauth
-gmpy2
 imageio
 nose-exclude
 solrpy

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,4 +6,4 @@ then
   echo "Removing previous coverage cache file"
   rm ".coverage"
 fi
-nosetests --with-doctest --with-coverage --cover-package=smqtk --exclude-dir-file=nose_exclude_dirs.txt python/smqtk
+nosetests --with-doctest --with-coverage --cover-package=smqtk --exclude-dir-file=nose_exclude_dirs.txt python/smqtk "$@"


### PR DESCRIPTION
Less than easy to set up and packaging them is problematic because of GPL/LGPL licenses.