### PR TITLE
Misc fixes

### DIFF
--- a/bin/scripts/iqr_app_model_generation.py
+++ b/bin/scripts/iqr_app_model_generation.py
@@ -59,7 +59,7 @@ data_set_config = {
     "DataFileSet": {
         "root_directory": "/Users/purg/dev/smqtk/source/data/FileDataSets/"
                           "example_image/data",
-        "sha1_chunk": 10
+        "uuid_chunk": 10
     }
 }
 

--- a/python/smqtk/representation/data_element/__init__.py
+++ b/python/smqtk/representation/data_element/__init__.py
@@ -24,7 +24,6 @@ class DataElement (Configurable):
     checksum accessor methods.
 
     """
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self):
         self._md5_cache = None

--- a/python/smqtk/representation/data_set/__init__.py
+++ b/python/smqtk/representation/data_set/__init__.py
@@ -70,8 +70,8 @@ class DataSet (collections.Set, Configurable):
     @abc.abstractmethod
     def __iter__(self):
         """
-        :return: Generator over the DataElements contained in this set in UUID
-            order, if sortable. If not, then in no particular order.
+        :return: Generator over the DataElements contained in this set in no
+            particular order.
         """
         return
 

--- a/python/smqtk/representation/data_set/__init__.py
+++ b/python/smqtk/representation/data_set/__init__.py
@@ -53,7 +53,6 @@ class DataSet (collections.Set, Configurable):
     def __getitem__(self, uuid):
         return self.get_data(uuid)
 
-    @abc.abstractmethod
     def __contains__(self, d):
         """
         Different than has_uuid() because this takes another DataElement
@@ -66,7 +65,7 @@ class DataSet (collections.Set, Configurable):
         :rtype: bool
 
         """
-        return
+        return self.has_uuid(d.uuid())
 
     @abc.abstractmethod
     def __iter__(self):

--- a/python/smqtk/representation/data_set/__init__.py
+++ b/python/smqtk/representation/data_set/__init__.py
@@ -15,7 +15,6 @@ class DataSet (collections.Set, Configurable):
     ``DataElement`` UUID values.
 
     """
-    __metaclass__ = abc.ABCMeta
 
     @classmethod
     @abc.abstractmethod

--- a/python/smqtk/representation/data_set/file_set.py
+++ b/python/smqtk/representation/data_set/file_set.py
@@ -86,18 +86,6 @@ class DataFileSet (DataSet):
         if self._new_elem_added:
             self._save_data_elements()
 
-    def __contains__(self, d):
-        """
-        :param d: DataElement to test for containment
-        :type d: smqtk.representation.DataElement
-
-        :return: True of this DataSet contains the given data element.
-        :rtype: bool
-
-        """
-        with self._element_map_lock:
-            return d.uuid() in self._element_map
-
     def __iter__(self):
         """
         :return: Generator over the DataElements contained in this set in UUID

--- a/python/smqtk/representation/data_set/file_set.py
+++ b/python/smqtk/representation/data_set/file_set.py
@@ -159,7 +159,6 @@ class DataFileSet (DataSet):
             assert isinstance(e, DataElement)
             uuid = str(e.uuid())
             fp = self._fp_for_uuid(uuid)
-            print "Adding to:", fp
             safe_create_dir(osp.dirname(fp))
             with open(fp, 'wb') as f:
                 cPickle.dump(e, f)

--- a/python/smqtk/representation/data_set/file_set.py
+++ b/python/smqtk/representation/data_set/file_set.py
@@ -1,5 +1,4 @@
 import cPickle
-import multiprocessing
 import os
 import os.path as osp
 import re
@@ -22,6 +21,7 @@ class DataFileSet (DataSet):
     to be picklable, so this is a valid assumption.
 
     """
+    # TODO: Use file-based locking mechanism to make thread/process safe
 
     # Filename template for serialized files. Requires template
     SERIAL_FILE_TEMPLATE = "UUID_%s.dataElement"

--- a/python/smqtk/representation/data_set/memory_set.py
+++ b/python/smqtk/representation/data_set/memory_set.py
@@ -1,0 +1,122 @@
+import multiprocessing
+
+from smqtk.representation import DataElement, DataSet
+
+
+__author__ = 'paul.tunison@kitware.com'
+
+
+class DataMemorySet (DataSet):
+    """
+    In-memory DataSet implementation. This does not support a persistant
+    representation.
+    """
+
+    @classmethod
+    def is_usable(cls):
+        """
+        Check whether this data set implementations is available for use.
+
+        This is always true for this implementation as there are no required 3rd
+        party dependencies
+
+        :return: Boolean determination of whether this implementation is usable.
+        :rtype: bool
+
+        """
+        return True
+
+    def __init__(self):
+        """
+        Initialize a new in-memory data set instance.
+        """
+        # Mapping of UUIDs to DataElement instances
+        #: :type: dict[collections.Hashable, DataElement]
+        self._element_map = {}
+        self._element_map_lock = multiprocessing.RLock()
+
+    def __iter__(self):
+        """
+        :return: Generator over the DataElements contained in this set in no
+            particular order.
+        """
+        # making copy of UUIDs so we don't block when between yields, as well as
+        # so we aren't walking a possibly modified map
+        uuids = self.uuids()
+        with self._element_map_lock:
+            for k in uuids:
+                yield self._element_map[k]
+
+    def get_config(self):
+        """
+        This implementation has no configuration properties.
+
+        :return: JSON type compliant configuration dictionary.
+        :rtype: dict
+
+        """
+        return {}
+
+    def count(self):
+        """
+        :return: The number of data elements in this set.
+        :rtype: int
+        """
+        with self._element_map_lock:
+            return len(self._element_map)
+
+    def uuids(self):
+        """
+        :return: A new set of uuids represented in this data set.
+        :rtype: set
+        """
+        with self._element_map_lock:
+            return set(self._element_map)
+
+    def has_uuid(self, uuid):
+        """
+        Test if the given uuid refers to an element in this data set.
+
+        :param uuid: Unique ID to test for inclusion. This should match the
+            type that the set implementation expects or cares about.
+
+        :return: True if the given uuid matches an element in this set, or
+            False if it does not.
+        :rtype: bool
+
+        """
+        with self._element_map_lock:
+            return uuid in self._element_map
+
+    def add_data(self, *elems):
+        """
+        Add the given data element(s) instance to this data set.
+
+        :param elems: Data element(s) to add
+        :type elems: list[smqtk.representation.DataElement]
+
+        """
+        with self._element_map_lock:
+            for e in elems:
+                assert isinstance(e, DataElement)
+                self._element_map[e.uuid()] = e
+
+    def get_data(self, uuid):
+        """
+        Get the data element the given uuid references, or raise an
+        exception if the uuid does not reference any element in this set.
+
+        :raises KeyError: If the given uuid does not refer to an element in
+            this data set.
+
+        :param uuid: The uuid of the element to retrieve.
+
+        :return: The data element instance for the given uuid.
+        :rtype: smqtk.representation.DataElement
+
+        """
+        with self._element_map_lock:
+            return self._element_map[uuid]
+
+
+DATA_SET_CLASS = DataMemorySet

--- a/python/smqtk/representation/descriptor_element/__init__.py
+++ b/python/smqtk/representation/descriptor_element/__init__.py
@@ -21,7 +21,6 @@ class DescriptorElement (Configurable):
     up for discussion).
 
     """
-    __metaclass__ = abc.ABCMeta
 
     def __init__(self, type_str, uuid):
         """

--- a/python/smqtk/tests/representation/DataSet/test_DataSet_abstract.py
+++ b/python/smqtk/tests/representation/DataSet/test_DataSet_abstract.py
@@ -20,9 +20,6 @@ class DummyDataSet (DataSet):
         for e in self.stuff:
             yield e
 
-    def __contains__(self, d):
-        pass
-
     def has_uuid(self, uuid):
         pass
 

--- a/python/smqtk/tests/representation/DataSet/test_FileSet.py
+++ b/python/smqtk/tests/representation/DataSet/test_FileSet.py
@@ -1,8 +1,6 @@
-import mock
 import nose.tools as ntools
 import unittest
 
-from smqtk.representation.data_element.memory_element import DataMemoryElement
 from smqtk.representation.data_set.file_set import DataFileSet
 
 
@@ -11,25 +9,11 @@ __author__ = "paul.tunison@kitware.com"
 
 class TestDataFileSet (unittest.TestCase):
 
-    @mock.patch.object(DataFileSet, '_save_data_elements')
-    def test_data_serialization(self, m_dfs_sde):
-        save_dir = '/not/a/real/dir'
-
-        ds = DataFileSet(save_dir)
-        del ds
-        ntools.assert_false(m_dfs_sde.called)
-
-        ds = DataFileSet(save_dir)
-        de = DataMemoryElement('foo', 'text/plain')
-        ds.add_data(de)
-        del ds
-        ntools.assert_true(m_dfs_sde.called)
-
     def test_configuration(self):
         default_config = DataFileSet.get_default_config()
         ntools.assert_equal(default_config, {
             'root_directory': None,
-            'sha1_chunk': 10,
+            'uuid_chunk': 10,
         })
 
         default_config['root_directory'] = '/some/dir'

--- a/python/smqtk/tests/representation/DataSet/test_MemorySet.py
+++ b/python/smqtk/tests/representation/DataSet/test_MemorySet.py
@@ -1,0 +1,21 @@
+import nose.tools as ntools
+import unittest
+
+from smqtk.representation.data_set.memory_set import DataMemorySet
+
+
+__author__ = "paul.tunison@kitware.com"
+
+
+class TestDataFileSet (unittest.TestCase):
+
+    def test_configuration(self):
+        default_config = DataMemorySet.get_default_config()
+        ntools.assert_equal(default_config, {})
+
+        inst1 = DataMemorySet.from_config(default_config)
+        # idempotency
+        ntools.assert_equal(default_config, inst1.get_config())
+
+        inst2 = DataMemorySet.from_config(inst1.get_config())
+        ntools.assert_equal(inst1, inst2)

--- a/python/smqtk/tests/representation/DataSet/test_plugins.py
+++ b/python/smqtk/tests/representation/DataSet/test_plugins.py
@@ -8,3 +8,4 @@ __author__ = "paul.tunison@kitware.com"
 def test_plugin_getter():
     c = get_data_set_impls()
     assert 'DataFileSet' in c
+    assert 'DataMemorySet' in c

--- a/python/smqtk/utils/file_utils.py
+++ b/python/smqtk/utils/file_utils.py
@@ -40,18 +40,13 @@ def iter_directory_files(d, recurse=True):
     :rtype: collections.Iterable[str]
 
     """
+    # TODO: Update this to use os.walk
     d = os.path.abspath(d)
-    for f in os.listdir(d):
-        f = os.path.join(d, f)
-        if os.path.isfile(f):
-            yield f
-        elif os.path.isdir(f):
-            if recurse:
-                for sf in iter_directory_files(f, recurse):
-                    yield sf
-        else:
-            raise RuntimeError("Encountered something not a file or "
-                               "directory? :: '%s'" % f)
+    for dirpath, dirnames, filenames in os.walk(d):
+        for fname in filenames:
+            yield os.path.join(dirpath, fname)
+        if not recurse:
+            break
 
 
 def exclusive_touch(file_path):

--- a/python/smqtk/web/search_app/config.IqrSearchApp.json
+++ b/python/smqtk/web/search_app/config.IqrSearchApp.json
@@ -12,7 +12,7 @@
             "data_set": {
                 "DataFileSet": {
                     "root_directory": "/Users/purg/dev/smqtk/source/data/FileDataSets/example_image/data",
-                    "sha1_chunk": 10
+                    "uuid_chunk": 10
                 },
                 "type": "DataFileSet"
             },


### PR DESCRIPTION
Fixes discovered and made while writing some documentation.
* Separated out old DataFileSet into DataMemorySet and DataFileSet, as the old implementation acted like both.
* Cleaned up repeated metaclass assignments
* updated directory file iterator to use ``os.walk``
* Updated configuration file use of ``uuid_chunk`` (used to be ``sha1_chunk``).