### PR TITLE
Removed default FLANN model filepaths

### DIFF
--- a/python/smqtk/algorithms/nn_index/flann.py
+++ b/python/smqtk/algorithms/nn_index/flann.py
@@ -39,31 +39,49 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         # TODO: check that underlying library is found/valid?
         return pyflann is not None
 
-    def __init__(self, index_filepath="index.flann",
-                 parameters_filepath="index_parameters.pickle",
-                 descriptor_cache_filepath="descriptor_cache.pickle",
+    def __init__(self, index_filepath=None, parameters_filepath=None,
+                 descriptor_cache_filepath=None,
                  # Parameters for building an index
                  autotune=False, target_precision=0.95, sample_fraction=0.1,
                  distance_method='hik', random_seed=None):
         """
         Initialize FLANN index properties. Does not contain a query-able index
-        until one is built via the ``build_index`` method, or loaded from save
-        file via the ``load_index`` method.
+        until one is built via the ``build_index`` method, or loaded from
+        existing model files.
 
-        Optional parameters are for when building the index. Documentation on
-        their meaning can be found in the FLANN documentation PDF:
+        When using this algorithm in a multiprocessing environment, the model
+        file path parameters must be specified due to needing to reload the
+        FLANN index on separate processes. This is because FLANN is in C and its
+        instances are not copied into processes.
+
+        Documentation on index building parameters and their meaning can be
+        found in the FLANN documentation PDF:
 
             http://www.cs.ubc.ca/research/flann/uploads/FLANN/flann_manual-1.8.4.pdf
 
         See the MATLAB section for detailed descriptions (python section will
         just point you to the MATLAB section).
 
-        :param index_filepath: File location to load/store FLANN index when
-            initialized and/or built.
-        :param parameters_filepath: File location to load/save FLANN index
-            parameters determined at build time.
-        :param descriptor_cache_filepath: File location to load/store
+        :param index_filepath: Optional file location to load/store FLANN index
+            when initialized and/or built.
+
+            If not configured, no model files are written to or loaded from
+            disk.
+        :type index_filepath: None | str
+
+        :param parameters_filepath: Optional file location to load/save FLANN
+            index parameters determined at build time.
+
+            If not configured, no model files are written to or loaded from
+            disk.
+        :type parameters_filepath: None | str
+
+        :param descriptor_cache_filepath: Optional file location to load/store
             DescriptorElements in this index.
+
+            If not configured, no model files are written to or loaded from
+            disk.
+        :type descriptor_cache_filepath: None | str
 
         :param autotune: Whether or not to perform parameter auto-tuning when
             building the index. If this is False, then the `target_precision`
@@ -96,6 +114,7 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         self._index_filepath = normpath(index_filepath)
         self._index_param_filepath = normpath(parameters_filepath)
         self._descr_cache_filepath = normpath(descriptor_cache_filepath)
+        # Now they're either None or an absolute path
 
         # parameters for building an index
         self._build_autotune = autotune
@@ -130,13 +149,6 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         # Load the index/parameters if one exists
         if self._has_model_files():
             self._log.info("Found existing model files. Loading.")
-            # Load descriptor cache
-            # - is copied on fork, so only need to load here.
-            self._log.debug("Loading cached descriptors")
-            with open(self._descr_cache_filepath, 'rb') as f:
-                self._descr_cache = cPickle.load(f)
-
-            self._log.debug("Loading cached FLANN model")
             self._load_flann_model()
 
     def get_config(self):
@@ -153,29 +165,39 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
 
     def _has_model_files(self):
         """
-        check if configured model files exist
+        check if configured model files are configured and exist
         """
-        return (osp.isfile(self._index_filepath) and
-                osp.isfile(self._index_param_filepath) and
-                osp.isfile(self._descr_cache_filepath))
+        return (self._index_filepath and osp.isfile(self._index_filepath) and
+                self._index_param_filepath and osp.isfile(self._index_param_filepath) and
+                self._descr_cache_filepath and osp.isfile(self._descr_cache_filepath))
 
     def _load_flann_model(self):
-        # Params pickle include the build params + our local state params
-        with open(self._index_param_filepath) as f:
-            state = cPickle.load(f)
-        self._build_autotune = state['b_autotune']
-        self._build_target_precision = state['b_target_precision']
-        self._build_sample_frac = state['b_sample_frac']
-        self._distance_method = state['distance_method']
-        self._flann_build_params = state['flann_build_params']
+        if not self._descr_cache and self._descr_cache_filepath:
+            # Load descriptor cache
+            # - is copied on fork, so only need to load here.
+            self._log.debug("Loading cached descriptors")
+            with open(self._descr_cache_filepath, 'rb') as f:
+                self._descr_cache = cPickle.load(f)
 
-        # make numpy matrix of descriptor vectors for FLANN
-        pts_array = [d.vector() for d in self._descr_cache]
-        pts_array = numpy.array(pts_array, dtype=pts_array[0].dtype)
-        pyflann.set_distance_type(self._distance_method)
-        self._flann = pyflann.FLANN()
-        self._flann.load_index(self._index_filepath, pts_array)
-        del pts_array
+        # Params pickle include the build params + our local state params
+        if self._index_param_filepath:
+            with open(self._index_param_filepath) as f:
+                state = cPickle.load(f)
+            self._build_autotune = state['b_autotune']
+            self._build_target_precision = state['b_target_precision']
+            self._build_sample_frac = state['b_sample_frac']
+            self._distance_method = state['distance_method']
+            self._flann_build_params = state['flann_build_params']
+
+        # Load the binary index
+        if self._index_filepath:
+            # make numpy matrix of descriptor vectors for FLANN
+            pts_array = [d.vector() for d in self._descr_cache]
+            pts_array = numpy.array(pts_array, dtype=pts_array[0].dtype)
+            pyflann.set_distance_type(self._distance_method)
+            self._flann = pyflann.FLANN()
+            self._flann.load_index(self._index_filepath, pts_array)
+            del pts_array
 
         # Set current PID to the current
         self._pid = multiprocessing.current_process().pid
@@ -188,7 +210,8 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         If there is a loaded index and we're on the same process that created it
         this does nothing.
         """
-        if bool(self._flann) and self._has_model_files() \
+        if bool(self._flann) \
+                and self._has_model_files() \
                 and self._pid != multiprocessing.current_process().pid:
             self._load_flann_model()
 
@@ -228,9 +251,12 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         self._descr_cache = list(descriptors)
         if not self._descr_cache:
             raise ValueError("No data provided in given iterable.")
-        self._log.debug("Caching descriptors: %s", self._descr_cache_filepath)
-        with open(self._descr_cache_filepath, 'wb') as f:
-            cPickle.dump(self._descr_cache, f)
+        # Cache descriptors if we have a path
+        if self._descr_cache_filepath:
+            self._log.debug("Caching descriptors: %s",
+                            self._descr_cache_filepath)
+            with open(self._descr_cache_filepath, 'wb') as f:
+                cPickle.dump(self._descr_cache, f)
 
         params = {
             "target_precision": self._build_target_precision,
@@ -254,16 +280,21 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
 
         self._log.debug("Caching index and state: %s, %s",
                         self._index_filepath, self._index_param_filepath)
-        self._flann.save_index(self._index_filepath)
-        state = {
-            'b_autotune': self._build_autotune,
-            'b_target_precision': self._build_target_precision,
-            'b_sample_frac': self._build_sample_frac,
-            'distance_method': self._distance_method,
-            'flann_build_params': self._flann_build_params,
-        }
-        with open(self._index_param_filepath, 'w') as f:
-            cPickle.dump(state, f)
+        if self._index_filepath:
+            self._log.debug("Caching index: %s", self._index_filepath)
+            self._flann.save_index(self._index_filepath)
+        if self._index_param_filepath:
+            self._log.debug("Caching index params: %s",
+                            self._index_param_filepath)
+            state = {
+                'b_autotune': self._build_autotune,
+                'b_target_precision': self._build_target_precision,
+                'b_sample_frac': self._build_sample_frac,
+                'distance_method': self._distance_method,
+                'flann_build_params': self._flann_build_params,
+            }
+            with open(self._index_param_filepath, 'w') as f:
+                cPickle.dump(state, f)
 
         self._pid = multiprocessing.current_process().pid
 


### PR DESCRIPTION
Now, when no file paths are provided, model is only maintained in memory
and lost when instance is deleted. Desired so the implementation doesn't write files to disk when used naively.