### PR TITLE
CNN and HBase update for IQR

### DIFF
--- a/bin/scripts/runners/memex_hbase_gpu_machine/compute.py
+++ b/bin/scripts/runners/memex_hbase_gpu_machine/compute.py
@@ -378,7 +378,7 @@ class CaffeDescriptorGenerator (multiprocessing.Process):
         })
         fd, protoconfig_filepath = tempfile.mkstemp(suffix='.prototxt', dir=TEMP_DIR)
         os.close(fd)
-        with open(protoconfig_filepath, 'w')  as ofile:
+        with open(protoconfig_filepath, 'w') as ofile:
             ofile.write(config_str)
 
         # Call executable

--- a/bin/scripts/runners/memex_hbase_gpu_machine/itq_training/add_codes.py
+++ b/bin/scripts/runners/memex_hbase_gpu_machine/itq_training/add_codes.py
@@ -1,0 +1,199 @@
+import cPickle
+import logging
+import multiprocessing
+import re
+import time
+
+import numpy as np
+
+from smqtk.algorithms.nn_index.lsh.itq import ITQNearestNeighborsIndex
+from smqtk.representation.descriptor_element.local_elements import DescriptorFileElement
+from smqtk.utils import SmqtkObject
+from smqtk.utils.bin_utils import initialize_logging
+from smqtk.utils.bit_utils import bit_vector_to_int
+
+from load_algo import load_algo
+
+
+DESCRIPTORS_ROOT_DIR = "/data/kitware/smqtk/image_cache_cnn_compute/descriptors"
+DESCRIPTORS_FILE_NAMES = "/data/kitware/smqtk/image_cache_cnn_compute/descriptor_file_names.5.3mil.pickle"
+ITQ_ROTATION = "/data/kitware/smqtk/image_cache_cnn_compute/itq_model/256-bit/rotation.npy"
+ITQ_MEAN_VEC = "/data/kitware/smqtk/image_cache_cnn_compute/itq_model/256-bit/mean_vec.npy"
+
+
+fn_sha1_re = re.compile("\w+\.(\w+)\.vector\.npy")
+
+
+#
+# Multiprocessing of ITQ small-code generation
+#
+def make_element(sha1):
+    return DescriptorFileElement("CaffeDefaultImageNet", sha1,
+                                 DESCRIPTORS_ROOT_DIR,
+                                 10)
+
+
+def make_elements_from_filenames(filenames):
+    for fn in filenames:
+        yield make_element(fn_sha1_re.match(fn).group(1))
+
+
+class SmallCodeProcess (SmqtkObject, multiprocessing.Process):
+    """
+    Worker process for ITQ smallcode generation given a rotation matrix and mean vector.
+
+    Input queue format: DescriptorFileElement
+    Output queue format: (int|long, DescriptorFileElement)
+
+    Terminal value: None
+
+    """
+
+    # class ItqShell (ITQNearestNeighborsIndex):
+    #     """
+    #     Shell subclass for access to small-code calculation method
+    #     """
+    #     def __init__(self, rot, mean_vec):
+    #         super(SmallCodeProcess.ItqShell, self).__init__(code_index=None)
+    #         self._r = rot
+    #         self._mean_vector = mean_vec
+
+    def __init__(self, i, in_q, out_q, r, mean_vec, batch=500):
+        super(SmallCodeProcess, self).__init__()
+        self._log.debug("[%s] Starting worker", self.name)
+        self.in_q = in_q
+        self.out_q = out_q
+        self.r = r
+        self.m_vec = mean_vec
+        self.batch = batch
+
+    def run(self):
+        # shell = self.ItqShell(self.r, self.m_vec)
+
+        packet = self.in_q.get()
+        d_elems = []
+        while packet:
+            # self._log.debug("[%s] Packet: %s", self.name, packet)
+            descr_elem = packet
+            # self.out_q.put((shell.get_small_code(descr_elem), 
+            #                 descr_elem))
+
+            d_elems.append(descr_elem)
+            if len(d_elems) >= self.batch:
+                self._log.debug("[%s] Computing batch of %d", self.name, len(d_elems))
+                m = np.array([d.vector() for d in d_elems])
+                z = np.dot((m - self.m_vec), self.r)
+                b = np.zeros(z.shape, dtype=np.uint8)
+                b[z >= 0] = 1
+                for bits, d in zip(b, d_elems):
+                    self.out_q.put((bit_vector_to_int(bits), d))
+                d_elems = []
+
+            packet = self.in_q.get()
+
+        if d_elems:
+            self._log.debug("[%s] Computing batch of %d", self.name, len(d_elems))
+            m = np.array([d.vector() for d in d_elems])
+            z = np.dot((m - self.m_vec), self.r)
+            b = np.zeros(z.shape, dtype=np.uint8)
+            b[z >= 0] = 1
+            for bits, d in zip(b, d_elems):
+                self.out_q.put((bit_vector_to_int(bits), d))
+            d_elems = []
+
+
+def async_compute_smallcodes(r, mean_vec, descr_elements,
+                             procs=None, report_interval=1.):
+    """
+    Yields (int|long, DescriptorElement)
+    """
+    log = logging.getLogger(__name__)
+
+    if procs is None:
+        procs = multiprocessing.cpu_count()
+
+    in_q = multiprocessing.Queue()
+    out_q = multiprocessing.Queue(procs*2)
+
+    workers = [SmallCodeProcess(i, in_q, out_q, r, mean_vec) for i in range(procs)]
+    for w in workers:
+        w.daemon = True
+
+    sc_d_return = []
+    try:
+        log.info("Starting worker processes")
+        for w in workers:
+            w.start()
+
+        log.info("Sending elements")
+        s = 0
+        lt = t = time.time()
+        for de in descr_elements:
+            in_q.put(de)
+            
+            s += 1
+            if time.time() - lt >= report_interval:
+                log.debug("Sent packets per second: %f, Total: %d",
+                    s / (time.time() - t), s
+                )
+                lt = time.time()
+        # Send terminal packets at tail
+        for w in workers:
+            in_q.put(None)
+        in_q.close()
+
+        log.info("Collecting small codes")
+        r = 0
+        lt = t = time.time()
+        for i in xrange(s):
+            sc, d = out_q.get()
+            sc_d_return.append((sc, d))
+
+            r += 1
+            if time.time() - lt >= report_interval:
+                log.debug("Collected packets per second: %f, Total: %d",
+                    r / (time.time() - t), r
+                )
+                lt = time.time()
+        out_q.close()
+        log.info("Scanned all smallcodes")
+
+        return sc_d_return
+        
+    finally:
+        for w in workers:
+            if w.is_alive():
+                w.terminate()
+            w.join()
+        for q in (in_q, out_q):
+            q.close()
+            q.join_thread()
+
+
+def add_descriptors_smallcodes():
+    log = logging.getLogger(__name__)
+
+    log.info("Loading descriptor file names")
+    with open(DESCRIPTORS_FILE_NAMES) as f:
+        descriptor_filenames = cPickle.load(f)
+    log.info("Loading ITQ components")
+    r = np.load(ITQ_ROTATION)
+    mv = np.load(ITQ_MEAN_VEC)
+
+    log.info("Making SC iterator")
+    sc_d_pairs = async_compute_smallcodes(
+        r, mv, make_elements_from_filenames(descriptor_filenames)
+    )
+
+    log.info("Loading ITQ model")
+    itq_index = load_algo()
+
+    log.info("Adding small codes")
+    itq_index._code_index.add_many_descriptors(sc_d_pairs)
+
+    return descriptor_filenames, itq_index
+
+
+if __name__ == "__main__":
+    initialize_logging(logging.getLogger(), logging.DEBUG)
+    filenames, itq_index = add_descriptors_smallcodes()

--- a/bin/scripts/runners/memex_hbase_gpu_machine/itq_training/load_algo.py
+++ b/bin/scripts/runners/memex_hbase_gpu_machine/itq_training/load_algo.py
@@ -1,0 +1,12 @@
+import json
+import smqtk.algorithms.nn_index.lsh.itq
+
+
+JSON_CONFIG_FP = "/data/kitware/smqtk/image_cache_cnn_compute/itq_model/256-bit/itq_config.json"
+
+
+def load_algo(m=smqtk.algorithms.nn_index.lsh.itq):
+    with open(JSON_CONFIG_FP) as f:
+        itq_config = json.load(f)
+    itq_index = m.ITQNearestNeighborsIndex.from_config(itq_config)
+    return itq_index

--- a/bin/scripts/runners/memex_hbase_gpu_machine/itq_training/train_model.py
+++ b/bin/scripts/runners/memex_hbase_gpu_machine/itq_training/train_model.py
@@ -1,0 +1,19 @@
+from smqtk.utils.bin_utils import logging, initialize_logging
+if not logging.getLogger().handlers:
+    initialize_logging(logging.getLogger(), logging.DEBUG)
+log = logging.getLogger(__name__)
+
+
+DESCRIPTORS_PICKLE = "/data/kitware/smqtk/image_cache_cnn_compute/DescriptorElement.1mil_sample.pickle"
+
+
+log.info("Loading descriptor elements")
+import cPickle
+with open(DESCRIPTORS_PICKLE) as f:
+    descr_elements = cPickle.load(f)
+
+
+log.info("Building index")
+from load_algo import load_algo
+itq_index = load_algo()
+x = itq_index.build_index(descr_elements)

--- a/python/smqtk/algorithms/descriptor_generator/__init__.py
+++ b/python/smqtk/algorithms/descriptor_generator/__init__.py
@@ -108,14 +108,15 @@ class DescriptorGenerator (SmqtkAlgorithm):
             implementation such storage.
         :type overwrite: bool
 
-        :param parallel: Optionally specification of how many processors to use
+        :param procs: Optional specification of how many processors to use
             when pooling sub-tasks. If None, we attempt to use all available
             cores.
-        :type parallel: int
+        :type procs: int
 
         :param pool_type: multiprocessing pool type to use. If no provided, we
-            use a normal multiprocessing.pool.Pool instance.
-        :type pool_type: type
+            use a normal multiprocessing.pool.Pool instance. By default we use
+            the ThreadPool type when None.
+        :type pool_type: type | None
 
         :return: Mapping of input DataElement instances to the computed
             descriptor element.
@@ -135,9 +136,9 @@ class DescriptorGenerator (SmqtkAlgorithm):
         de_map = {}
 
         # Queue up descriptor generation for descriptor elements that
-        parallel = kwds.get('parallel', None)
-        pool_t = kwds.get('pool_type', multiprocessing.pool.ThreadPool)
-        pool = pool_t(processes=parallel)
+        procs = kwds.get("procs", None)
+        pool_t = kwds.get("pool_type", multiprocessing.pool.ThreadPool)
+        pool = pool_t(processes=procs)
         with SimpleTimer("Queuing descriptor computation...", self._log.debug):
             for d in data_iter:
                 de_map[d] = descr_factory.new_descriptor(self.name, d.uuid())

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/__init__.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/__init__.py
@@ -1,0 +1,7 @@
+from .descriptor import CaffeDefaultImageNet
+
+
+__author__ = 'paul.tunison@kitware.com'
+
+
+DESCRIPTOR_GENERATOR_CLASS = CaffeDefaultImageNet

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/cnn_config.prototxt.tmpl
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/cnn_config.prototxt.tmpl
@@ -1,0 +1,238 @@
+name: "CaffeNet"
+layer {
+  name: "data"
+  type: "ImageData"
+  top: "data"
+  top: "label"
+  transform_param {
+    mirror: false
+    crop_size: 227
+    mean_file: "{{ image_mean_filepath }}"
+  }
+  image_data_param {
+    source: "{{ image_filelist_filepath }}"
+    batch_size: {{ batch_size }}
+    new_height: 256
+    new_width: 256
+  }
+}
+layer {
+  name: "conv1"
+  type: "Convolution"
+  bottom: "data"
+  top: "conv1"
+  convolution_param {
+    num_output: 96
+    kernel_size: 11
+    stride: 4
+  }
+}
+layer {
+  name: "relu1"
+  type: "ReLU"
+  bottom: "conv1"
+  top: "conv1"
+}
+layer {
+  name: "pool1"
+  type: "Pooling"
+  bottom: "conv1"
+  top: "pool1"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layer {
+  name: "norm1"
+  type: "LRN"
+  bottom: "pool1"
+  top: "norm1"
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layer {
+  name: "conv2"
+  type: "Convolution"
+  bottom: "norm1"
+  top: "conv2"
+  convolution_param {
+    num_output: 256
+    pad: 2
+    kernel_size: 5
+    group: 2
+  }
+}
+layer {
+  name: "relu2"
+  type: "ReLU"
+  bottom: "conv2"
+  top: "conv2"
+}
+layer {
+  name: "pool2"
+  type: "Pooling"
+  bottom: "conv2"
+  top: "pool2"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layer {
+  name: "norm2"
+  type: "LRN"
+  bottom: "pool2"
+  top: "norm2"
+  lrn_param {
+    local_size: 5
+    alpha: 0.0001
+    beta: 0.75
+  }
+}
+layer {
+  name: "conv3"
+  type: "Convolution"
+  bottom: "norm2"
+  top: "conv3"
+  convolution_param {
+    num_output: 384
+    pad: 1
+    kernel_size: 3
+  }
+}
+layer {
+  name: "relu3"
+  type: "ReLU"
+  bottom: "conv3"
+  top: "conv3"
+}
+layer {
+  name: "conv4"
+  type: "Convolution"
+  bottom: "conv3"
+  top: "conv4"
+  convolution_param {
+    num_output: 384
+    pad: 1
+    kernel_size: 3
+    group: 2
+  }
+}
+layer {
+  name: "relu4"
+  type: "ReLU"
+  bottom: "conv4"
+  top: "conv4"
+}
+layer {
+  name: "conv5"
+  type: "Convolution"
+  bottom: "conv4"
+  top: "conv5"
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    group: 2
+  }
+}
+layer {
+  name: "relu5"
+  type: "ReLU"
+  bottom: "conv5"
+  top: "conv5"
+}
+layer {
+  name: "pool5"
+  type: "Pooling"
+  bottom: "conv5"
+  top: "pool5"
+  pooling_param {
+    pool: MAX
+    kernel_size: 3
+    stride: 2
+  }
+}
+layer {
+  name: "fc6"
+  type: "InnerProduct"
+  bottom: "pool5"
+  top: "fc6"
+  inner_product_param {
+    num_output: 4096
+  }
+}
+layer {
+  name: "relu6"
+  type: "ReLU"
+  bottom: "fc6"
+  top: "fc6"
+}
+layer {
+  name: "drop6"
+  type: "Dropout"
+  bottom: "fc6"
+  top: "fc6"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
+  name: "fc7"
+  type: "InnerProduct"
+  bottom: "fc6"
+  top: "fc7"
+  inner_product_param {
+    num_output: 4096
+  }
+}
+layer {
+  name: "relu7"
+  type: "ReLU"
+  bottom: "fc7"
+  top: "fc7"
+}
+layer {
+  name: "drop7"
+  type: "Dropout"
+  bottom: "fc7"
+  top: "fc7"
+  dropout_param {
+    dropout_ratio: 0.5
+  }
+}
+layer {
+  name: "fc8"
+  type: "InnerProduct"
+  bottom: "fc7"
+  top: "fc8"
+  inner_product_param {
+    num_output: 1000
+  }
+}
+layer {
+  name: "prob"
+  type: "Softmax"
+  bottom: "fc8"
+  top: "prob"
+}
+layer {
+  name: "accuracy"
+  type: "Accuracy"
+  bottom: "prob"
+  bottom: "label"
+  top: "accuracy"
+}
+layer {
+  name: "loss"
+  type: "SoftmaxWithLoss"
+  bottom: "fc8"
+  bottom: "label"
+  top: "loss"
+}

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
@@ -1,0 +1,46 @@
+from smqtk.algorithms.descriptor_generator import DescriptorGenerator
+
+
+__author__ = 'paul.tunison@kitware.com'
+
+
+class CaffeDefaultImageNet (DescriptorGenerator):
+    """
+    Descriptor generator using the pre-trained AlexNet CNN network, yielding
+    a 4096 length descriptor vector.
+    """
+
+    EXE_PATH = "cnn_feature_extractor"
+
+    @classmethod
+    def is_usable(cls):
+        # Try to call the executable which needs to be on the PATH
+        return True
+
+    def get_config(self):
+        return {}
+
+    def valid_content_types(self):
+        return {
+            'image/tiff',
+            'image/png',
+            'image/jpeg',
+        }
+
+    def _compute_descriptor(self, data):
+        # For actual implementation, see the
+        # bin/scripts/runners/memex_hbase_gpu_machine/compute.py file.
+        raise NotImplementedError("Currently expecting only data that has been "
+                                  "computed before")
+
+    def compute_descriptor_async(self, data_iter, descr_factory,
+                                 overwrite=False, **kwds):
+        # Create DescriptorElement instances for each data elem.
+        # Queue up for processing data that doesn't have descriptors computed
+        #   for it yet.
+        # Generate necessary files for exe, write temp files for data, compute
+        #   batch descriptors (with GPU if a flag is set, constructor param).
+        # Convert result types are return merged set.
+        raise NotImplementedError("%s async descriptor computation will have a "
+                                  "custom implementation, but this is not yet "
+                                  "complete." % self.name)

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
@@ -1,21 +1,78 @@
+import tempfile
+import multiprocessing
+import multiprocessing.pool
+import os
+import subprocess
+
+import jinja2
+
 from smqtk.algorithms.descriptor_generator import DescriptorGenerator
+from smqtk.utils.file_utils import iter_csv_file
 
 
 __author__ = 'paul.tunison@kitware.com'
+
 
 
 class CaffeDefaultImageNet (DescriptorGenerator):
     """
     Descriptor generator using the pre-trained AlexNet CNN network, yielding
     a 4096 length descriptor vector.
+
+    Additional large files must be downloaded from Caffe in order to use this
+    descriptor generator:
+        - BVLC reference CaffeNet (233MB)
+            http://dl.caffe.berkeleyvision.org/bvlc_reference_caffenet.caffemodel
+        - ImageNet image mean (17MB)
+            extract the ``imagenet_mean.binaryproto`` file from:
+                http://dl.caffe.berkeleyvision.org/caffe_ilsvrc12.tar.gz
+
+    The paths to these files should be passed to the
+    ``blvc_reference_caffenet_model_fp`` and ``image_mean_binary_fp`` constructor
+    parameters respectively.
+
+    This implementation is currently intended to be run on a GPU, though it may
+    work on CPU-only caffe installations.
+
     """
 
-    EXE_PATH = "cnn_feature_extractor"
+    PROTOTEXT_TEMPLATE = jinja2.Template(
+        open(os.path.join(os.path.dirname(__file__),
+                          "cnn_config.prototxt.tmpl")).read()
+    )
 
     @classmethod
     def is_usable(cls):
         # Try to call the executable which needs to be on the PATH
         return True
+
+    def __init__(self, blvc_reference_caffenet_model, image_mean_binary,
+                 gpu_batch_size,
+                 layer_extraction='fc7',
+                 temp_directory=None,
+                 force_gpu=False,
+                 cnn_exe='cnn_feature_extractor'):
+        """
+        :param blvc_reference_caffenet_model: Path to the BVLC model file.
+        :param image_mean_binary: Path to the ImageNet image mean binary file.
+        :param gpu_batch_size: Number of concurrent images to send to the GPU at
+            a time. This is dependent on the RAM available to your GPU.
+        :param layer_extraction: Layer of the CNN to extract as the feature
+            vector.
+        :param temp_directory: Optional directory to store temporary working
+            files.
+        :param force_gpu: Force CNN computation on the GPU. Executable must be
+            built with this functionality enabled.
+        :param cnn_exe: Custom name or path to the executable to use.
+
+        """
+        self.blvc_reference_caffenet_model_fp = blvc_reference_caffenet_model
+        self.image_mean_binary_fp = image_mean_binary
+        self.gpu_batch_size = gpu_batch_size
+        self.layer_extraction = layer_extraction
+        self.temp_directory = temp_directory
+        self.force_gpu = force_gpu
+        self.cnn_exe = cnn_exe
 
     def get_config(self):
         return {}
@@ -30,17 +87,219 @@ class CaffeDefaultImageNet (DescriptorGenerator):
     def _compute_descriptor(self, data):
         # For actual implementation, see the
         # bin/scripts/runners/memex_hbase_gpu_machine/compute.py file.
-        raise NotImplementedError("Currently expecting only data that has been "
-                                  "computed before")
+        raise NotImplementedError("Shouldn't get here as compute_descriptor is "
+                                  "being overridden")
+
+    def compute_descriptor(self, data, descr_factory, overwrite=False):
+        """
+        Given some kind of data, return a descriptor element containing a
+        descriptor vector.
+
+        :raises RuntimeError: Descriptor extraction failure of some kind.
+        :raises ValueError: Given data element content was not of a valid type
+            with respect to this descriptor.
+
+        :param data: Some kind of input data for the feature descriptor.
+        :type data: smqtk.representation.DataElement
+
+        :param descr_factory: Factory instance to produce the wrapping
+            descriptor element instance.
+        :type descr_factory: smqtk.representation.DescriptorElementFactory
+
+        :param overwrite: Whether or not to force re-computation of a descriptor
+            vector for the given data even when there exists a precomputed
+            vector in the generated DescriptorElement as generated from the
+            provided factory. This will overwrite the persistently stored vector
+            if the provided factory produces a DescriptorElement implementation
+            with such storage.
+        :type overwrite: bool
+
+        :return: Result descriptor element. UUID of this output descriptor is
+            the same as the UUID of the input data element.
+        :rtype: smqtk.representation.DescriptorElement
+
+        """
+        # TODO: Could write custom process for slight optimization
+        #       over just calling the async version with one element.
+        m = self.compute_descriptor_async([data], descr_factory, overwrite,
+                                          procs=1)
+        return m[data]
 
     def compute_descriptor_async(self, data_iter, descr_factory,
-                                 overwrite=False, **kwds):
+                                 overwrite=False, procs=None, **kwds):
+        """
+        Asynchronously compute feature data for multiple data items.
+
+        This function does NOT use the class attribute PARALLEL for determining
+        parallel factor as this method can take that specification as an
+        argument.
+
+        :param data_iter: Iterable of data elements to compute features for.
+            These must have UIDs assigned for feature association in return
+            value.
+        :type data_iter: collections.Iterable[smqtk.representation.DataElement]
+
+        :param descr_factory: Factory instance to produce the wrapping
+            descriptor element instances.
+        :type descr_factory: smqtk.representation.DescriptorElementFactory
+
+        :param overwrite: Whether or not to force re-computation of a descriptor
+            vectors for the given data even when there exists precomputed
+            vectors in the generated DescriptorElements as generated from the
+            provided factory. This will overwrite the persistently stored
+            vectors if the provided factory produces a DescriptorElement
+            implementation such storage.
+        :type overwrite: bool
+
+        :param procs: Optional specification of how many processors to use
+            when pooling sub-tasks. If None, we attempt to use all available
+            cores.
+        :type procs: int
+
+        :return: Mapping of input DataElement instances to the computed
+            descriptor element.
+            DescriptorElement UUID's are congruent with the UUID of the data
+            element it is the descriptor of.
+        :rtype: dict[smqtk.representation.DataElement,
+                     smqtk.representation.DescriptorElement]
+
+        """
         # Create DescriptorElement instances for each data elem.
-        # Queue up for processing data that doesn't have descriptors computed
-        #   for it yet.
-        # Generate necessary files for exe, write temp files for data, compute
-        #   batch descriptors (with GPU if a flag is set, constructor param).
-        # Convert result types are return merged set.
-        raise NotImplementedError("%s async descriptor computation will have a "
-                                  "custom implementation, but this is not yet "
-                                  "complete." % self.name)
+        #: :type: dict[collections.Hashable, smqtk.representation.DataElement]
+        data_elements = {}
+        #: :type: dict[collections.Hashable, smqtk.representation.DescriptorElement]
+        descr_elements = {}
+        self._log.debug("Checking content types; aggregating data/descriptor "
+                        "elements.")
+        for d in data_iter:
+            ct = d.content_type()
+            if ct not in self.valid_content_types():
+                raise ValueError("Cannot compute descriptor of content type "
+                                 "'%s'" % ct)
+
+            data_elements[d.uuid()] = d
+            descr_elements[d.uuid()] = descr_factory.new_descriptor(self.name, d.uuid())
+
+        # Reduce procs down to the number of elements to process if its smaller
+        if len(data_elements) < (procs or multiprocessing.cpu_count()):
+            procs = len(data_elements)
+
+        # Queue up for processing UUID keys for data that don't have descriptors
+        #   computed for it yet.
+        #: :type: list[collections.Hashable]
+        key_queue = []
+        for d in descr_elements.itervalues():
+            if overwrite or not d.has_vector():
+                key_queue.append(d.uuid())
+
+        if key_queue:
+            # Split keys into two batches:
+            #   - one evenly divisible by configured GPU batch size
+            #   - remaining keys (tail)
+            main_batch_size = self.gpu_batch_size * (len(key_queue) // self.gpu_batch_size)
+            main_vectors = \
+                self._compute_even_batch(key_queue[:main_batch_size],
+                                         data_elements, descr_elements,
+                                         self.gpu_batch_size, procs)
+            # Assigning vectors to appropriate descriptors
+            for k, v in zip(key_queue[:main_batch_size], main_vectors):
+                descr_elements[k].set_vector(v)
+
+            # Compute trailing keys if the total queue wasn't evenly divisible
+            # by the GPU batch size.
+            if main_batch_size != len(key_queue):
+                tail_size = len(key_queue) - main_batch_size
+                tail_vectors = self._compute_even_batch(key_queue[-tail_size:],
+                                                        data_elements,
+                                                        descr_elements,
+                                                        tail_size, procs)
+                main_vectors.extend(tail_vectors)
+
+        return dict((data_elements[k], descr_elements[k])
+                    for k in data_elements)
+
+    def _compute_even_batch(self, keys, data_elements, descriptor_elements,
+                            gpu_batch_size, procs):
+        """
+        Helper for computing a number of elements that is easily subdivided by
+        the GPU batch size.
+        """
+        p = multiprocessing.pool.ThreadPool(procs)
+        list_filepath = tempfile.mkstemp(".txt", self.name+'.',
+                                         self.temp_directory)[1]
+        prototxt_filepath = tempfile.mkstemp('.prototxt', self.name+'.',
+                                             self.temp_directory)[1]
+
+        try:
+            self._log.debug("Writing temp files (threaded)")
+            p.map(CaffeDefaultImageNet._async_write_temp,
+                  ((data_elements[k], self.temp_directory)
+                   for k in keys))
+
+            if len(keys) % gpu_batch_size != 0:
+                raise ValueError("GPU batch size does not evenly divide ")
+            mini_batch_size = len(keys) // gpu_batch_size
+
+            self._log.debug("make image list file")
+            with open(list_filepath, 'w') as list_file:
+                for k in keys:
+                    list_file.write(
+                        data_elements[k].write_temp(self.temp_directory) +
+                        '\n'
+                    )
+
+            self._log.debug("Generate prototxt file")
+            prototxt_str = self.PROTOTEXT_TEMPLATE.render(**{
+                "image_mean_filepath": self.image_mean_binary_fp,
+                "image_filelist_filepath": list_filepath,
+                "batch_size": gpu_batch_size,
+            })
+            with open(prototxt_filepath, 'w') as f:
+                f.write(prototxt_str)
+
+            self._log.debug("Computing descriptors")
+            output_filebase = tempfile.mkstemp(prefix=self.name+'.',
+                                               dir=self.temp_directory)[1]
+            os.remove(output_filebase)
+            # The expected output CSV file path that will actually get
+            # generated.
+            output_csv = output_filebase + '.csv'
+            call_args = [
+                self.cnn_exe, self.blvc_reference_caffenet_model_fp,
+                prototxt_filepath, self.layer_extraction, output_filebase,
+                str(mini_batch_size), 'csv'
+            ]
+            if self.force_gpu:
+                call_args.append("GPU")
+            self._log.debug("CNN call args: %s", call_args)
+
+            proc_cnn = subprocess.Popen(call_args)
+            rc = proc_cnn.wait()
+            if rc:
+                raise RuntimeError("Failed CNN descriptor generation "
+                                   "execution with return code: %d"
+                                   % rc)
+            if not os.path.isfile(output_csv):
+                raise RuntimeError("Expected output CSV file not found, "
+                                   "but return code was 0.\n"
+                                   "Expected path:  %s" % output_csv)
+
+            return list(iter_csv_file(output_csv))
+
+        finally:
+            # Clean up resources used
+            p.close()
+            p.join()
+
+            if list_filepath:
+                os.remove(list_filepath)
+            if prototxt_filepath:
+                os.remove(prototxt_filepath)
+
+    @staticmethod
+    def _async_write_temp(packet):
+        """
+        :type packet: (smqtk.representation.DataElement, str | None)
+        """
+        data_element, output_dir = packet
+        data_element.write_temp(output_dir)

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
@@ -275,9 +275,11 @@ class CaffeDefaultImageNet (DescriptorGenerator):
             self._log.debug("make image list file")
             with open(list_filepath, 'w') as list_file:
                 for k in keys:
+                    # The ``write_temp`` call here is O(1) because it has
+                    # already been written via the async temp write above.
                     list_file.write(
-                        data_elements[k].write_temp(self.temp_directory) +
-                        '\n'
+                        "%s 0\n"
+                        % data_elements[k].write_temp(self.temp_directory)
                     )
 
             self._log.debug("Generate prototxt file")

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
@@ -101,8 +101,8 @@ class CaffeDefaultImageNet (DescriptorGenerator):
 
     def get_config(self):
         return {
-            "blvc_reference_caffenet_model_fp": self.blvc_reference_caffenet_model_fp,
-            "image_mean_binary_fp": self.image_mean_binary_fp,
+            "blvc_reference_caffenet_model": self.blvc_reference_caffenet_model_fp,
+            "image_mean_binary": self.image_mean_binary_fp,
             "gpu_batch_size": self.gpu_batch_size,
             "layer_extraction": self.layer_extraction,
             "temp_directory": self.temp_directory,

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
@@ -75,7 +75,15 @@ class CaffeDefaultImageNet (DescriptorGenerator):
         self.cnn_exe = cnn_exe
 
     def get_config(self):
-        return {}
+        return {
+            "blvc_reference_caffenet_model_fp": self.blvc_reference_caffenet_model_fp,
+            "image_mean_binary_fp": self.image_mean_binary_fp,
+            "gpu_batch_size": self.gpu_batch_size,
+            "layer_extraction": self.layer_extraction,
+            "temp_directory": self.temp_directory,
+            "force_gpu": self.force_gpu,
+            "cnn_exe": self.cnn_exe,
+        }
 
     def valid_content_types(self):
         return {
@@ -85,10 +93,9 @@ class CaffeDefaultImageNet (DescriptorGenerator):
         }
 
     def _compute_descriptor(self, data):
-        # For actual implementation, see the
-        # bin/scripts/runners/memex_hbase_gpu_machine/compute.py file.
-        raise NotImplementedError("Shouldn't get here as compute_descriptor is "
-                                  "being overridden")
+        raise NotImplementedError("Shouldn't get here as "
+                                  "compute_descriptor[_async] is being "
+                                  "overridden")
 
     def compute_descriptor(self, data, descr_factory, overwrite=False):
         """

--- a/python/smqtk/algorithms/nn_index/lsh/itq.py
+++ b/python/smqtk/algorithms/nn_index/lsh/itq.py
@@ -519,12 +519,12 @@ class ITQNearestNeighborsIndex (NearestNeighborsIndex):
                 break
 
         # Compute fine-grain distance measurements for collected elements + sort
-        # for d_elem in neighbors:
-        #     distances.append(self._dist_func(d_vec, d_elem.vector()))
+        self._log.debug("elements to numpy")
+        neighbor_vectors = elements_to_matrix(neighbors)
         self._log.debug("Sorting descriptors: %d", len(neighbors))
-        def comp_neighbor_dist(neighbor):
-            return self._dist_func(d_vec, neighbor.vector())
-        distances = map(comp_neighbor_dist, neighbors)
+        def comp_neighbor_dist(neighbor_vec):
+            return self._dist_func(d_vec, neighbor_vec)
+        distances = map(comp_neighbor_dist, neighbor_vectors)
 
         # Sort by distance, return top n
         self._log.debug("Forming output")

--- a/python/smqtk/algorithms/nn_index/lsh/itq.py
+++ b/python/smqtk/algorithms/nn_index/lsh/itq.py
@@ -3,6 +3,9 @@ Home of IQR LSH implementation based on UNC Chapel Hill paper / sample code.
 """
 
 import heapq
+import itertools
+import multiprocessing
+import multiprocessing.pool
 import os.path as osp
 
 import numpy
@@ -11,6 +14,7 @@ import numpy.matlib
 from smqtk.algorithms.nn_index import NearestNeighborsIndex
 from smqtk.representation.code_index import get_code_index_impls
 from smqtk.representation.code_index.memory import MemoryCodeIndex
+from smqtk.representation.descriptor_element.local_elements import DescriptorMemoryElement
 from smqtk.utils import (
     bit_utils,
     distance_functions,
@@ -322,6 +326,99 @@ class ITQNearestNeighborsIndex (NearestNeighborsIndex):
 
         return b, r
 
+    @staticmethod
+    def _proc_get_vector((row, d_elem, q)):
+        """
+        Should only be called from pool.map() with 3-element sequence arguments.
+
+        Get the vector from the element, and insert it into the given
+        multiprocessing.Queue. The queue will have a max size, so this will
+        block when the queue is full.
+
+        Queue will be pushed a tuple of the format:
+            ( row , npy-vector )
+
+        :param row: Integer row of the final matrix
+        :type row: int
+
+        :param d_elem: DescriptorElement instance
+        :type d_elem: smqtk.representation.DescriptorElement
+
+        :param q: Output queue
+        :type q: multiprocessing.Queue
+
+        """
+        q.put((row, d_elem.vector()))
+
+    @staticmethod
+    def _load_mat_async_proc(descriptor_elements, x):
+        """
+        Load DescriptorElement vectors into the given matrix ``x`` using a
+        multiprocessing approach.
+
+        :param descriptor_elements: Input descriptor elements
+        :type descriptor_elements: list[smqtk.representation.DescriptorElement]
+
+        :param x: output matrix
+        :type x: numpy.core.multiarray.ndarray
+
+        """
+        assert len(descriptor_elements) == x.shape[0], \
+            "Incompatible matrix height"
+        assert descriptor_elements[0].vector().size == x.shape[1], \
+            "Incompatible matrix width"
+
+        q = multiprocessing.Queue(multiprocessing.cpu_count() * 2)
+        p = multiprocessing.Pool()
+        p.map_async(ITQNearestNeighborsIndex._proc_get_vector,
+                    itertools.izip(
+                        xrange(len(descriptor_elements)),
+                        descriptor_elements,
+                        itertools.repeat(q, len(descriptor_elements))
+                    ))
+        # Aggregate results. Will need to only call q.get() as many times as
+        # there are input elements, thus the for-loop and no terminal value on
+        # queue.
+        for _ in descriptor_elements:
+            r, v = q.get()
+            x[r] = v
+
+        # x updated in place, no return
+
+    @staticmethod
+    def _thread_insert_vec((x, r, d_elem)):
+        """
+        Should only be called from pool.map() with 3-element sequence arguments.
+        """
+        x[r] = d_elem.vector()
+
+    @staticmethod
+    def _load_mat_async_thread(descriptor_elements, x):
+        """
+        Load descriptor element vectors into matrix ``x`` on threads
+
+        :param descriptor_elements: Input descriptor elements
+        :type descriptor_elements: list[smqtk.representation.DescriptorElement]
+
+        :param x: output matrix
+        :type x: numpy.core.multiarray.ndarray
+
+        """
+        assert len(descriptor_elements) == x.shape[0], \
+            "Incompatible matrix height"
+        assert descriptor_elements[0].vector().size == x.shape[1], \
+            "Incompatible matrix width"
+
+        p = multiprocessing.pool.ThreadPool()
+        p.map(ITQNearestNeighborsIndex._thread_insert_vec,
+              itertools.izip(
+                  itertools.repeat(x, len(descriptor_elements)),
+                  xrange(len(descriptor_elements)),
+                  descriptor_elements
+              ))
+
+        # x updated in place, no return
+
     def build_index(self, descriptors):
         """
         Build the index over the descriptor data elements.
@@ -358,16 +455,23 @@ class ITQNearestNeighborsIndex (NearestNeighborsIndex):
         if self._rand_seed:
             numpy.random.seed(self._rand_seed)
 
-        with SimpleTimer("Creating descriptor matrix", self._log.info):
-            x = []
+        with SimpleTimer("Creating descriptor cache", self._log.info):
             #: :type: list[smqtk.representation.DescriptorElement]
             descr_cache = []
             for d in descriptors:
                 descr_cache.append(d)
-                x.append(d.vector())
-            if not x:
+            if not descr_cache:
                 raise ValueError("No descriptors given!")
-            x = numpy.array(x)
+        with SimpleTimer("Creating matrix of descriptors for training",
+                         self._log.info):
+            # Get vectors on separate processes and aggregate into matrix x
+            vec_size = descr_cache[0].vector().size
+            x = numpy.ndarray((len(descr_cache), vec_size), float)
+            # max limit so we don't buffer too many things as a time
+            if isinstance(descr_cache[0], DescriptorMemoryElement):
+                self._load_mat_async_thread(descr_cache, x)
+            else:
+                self._load_mat_async_proc(descr_cache, x)
 
         with SimpleTimer("Centering data", self._log.info):
             # center the data, VERY IMPORTANT for ITQ to work

--- a/python/smqtk/algorithms/relevancy_index/libsvm_hik.py
+++ b/python/smqtk/algorithms/relevancy_index/libsvm_hik.py
@@ -236,6 +236,7 @@ class LibSvmHikRelevancyIndex (RelevancyIndex):
             raise ValueError("No negative examples provided.")
 
         # Training SVM model
+        self._log.debug("online model training")
         svm_problem = svm.svm_problem(train_labels, train_vectors)
         svm_model = svmutil.svm_train(svm_problem,
                                       self._gen_svm_parameter_string(num_pos,
@@ -247,6 +248,7 @@ class LibSvmHikRelevancyIndex (RelevancyIndex):
         # Platt Scaling for probability rankings
         #
 
+        self._log.debug("making test distance matrix")
         # Number of support vectors
         # Q: is this always the same as ``svm_model.l``?
         num_SVs = sum(svm_model.nSV[:svm_model.nr_class])
@@ -270,6 +272,7 @@ class LibSvmHikRelevancyIndex (RelevancyIndex):
                                              histogram_intersection_distance,
                                              row_wise=True)
 
+        self._log.debug("Platt scalling")
         # the actual platt scaling stuff
         weights = numpy.array(svm_model.get_sv_coef()).flatten()
         margins = numpy.dot(weights, svm_test_k)

--- a/python/smqtk/representation/data_element/hbase_element.py
+++ b/python/smqtk/representation/data_element/hbase_element.py
@@ -1,0 +1,79 @@
+from smqtk.representation import DataElement
+
+
+__author__ = 'paul.tunison@kitware.com'
+
+
+# attempt to import required modules
+try:
+    import happybase
+    import tika
+    from tika import detector as tika_detector
+except ImportError:
+    happybase = None
+    tika = None
+    tika_detector = None
+
+
+class HBaseDataElement (DataElement):
+    """
+    Wrapper for binary data contained on an HBase server somewhere. Uses Tika
+    content type detection to determine content type of served data.
+    """
+
+    @classmethod
+    def is_usable(cls):
+        return None not in {happybase, tika_detector}
+
+    def __init__(self, element_key, binary_column, hbase_address,
+                 hbase_table, timeout=10000):
+        """
+        Create a new HBase data element wrapper/reference.
+
+        :param element_key: Key to the table row containing the binary data
+        :type element_key: str
+
+        :param binary_column: Name of the column that contains the binary
+            data.
+        :type binary_column: str
+
+        :param hbase_address: Address of the HBase server. This should at least
+            be the hostname of the server. This might also take a ":port"
+            suffix?
+        :type hbase_address: str
+
+        :param hbase_table: Name of the table the content is contained in.
+        :param timeout:
+        :return:
+        """
+        super(HBaseDataElement, self).__init__()
+        self.element_key = element_key
+        self.binary_column = binary_column
+        self.hbase_address = hbase_address
+        self.hbase_table = hbase_table
+        self.timeout = int(timeout)
+
+        self._binary_ct_cache = None
+
+    def get_config(self):
+        return {
+            "element_key": self.element_key,
+            "binary_column": self.binary_column,
+            "hbase_address": self.hbase_address,
+            "hbase_table": self.hbase_table,
+            "timeout": self.timeout,
+        }
+
+    def content_type(self):
+        if self._binary_ct_cache is None:
+            self._binary_ct_cache = tika_detector.from_buffer(self.get_bytes())
+        return self._binary_ct_cache
+
+    def _new_hbase_table_connection(self):
+        return happybase.Connection(self.hbase_address, timeout=self.timeout)\
+            .table(self.hbase_table)
+
+    def get_bytes(self):
+        table = self._new_hbase_table_connection()
+        r = table.row(self.element_key, columns=[self.binary_column])
+        return r[self.binary_column]

--- a/python/smqtk/representation/data_element/hbase_element.py
+++ b/python/smqtk/representation/data_element/hbase_element.py
@@ -77,3 +77,6 @@ class HBaseDataElement (DataElement):
         table = self._new_hbase_table_connection()
         r = table.row(self.element_key, columns=[self.binary_column])
         return r[self.binary_column]
+
+
+DATA_ELEMENT_CLASS = HBaseDataElement

--- a/python/smqtk/representation/data_set/memory_set.py
+++ b/python/smqtk/representation/data_set/memory_set.py
@@ -72,7 +72,7 @@ class DataMemorySet (DataSet):
     def cache(self):
         if self.file_cache:
             with self._element_map_lock:
-                with SimpleTimer("Caching memory data-set table", self._log):
+                with SimpleTimer("Caching memory data-set table", self._log.info):
                     with open(self.file_cache, 'wb') as f:
                         cPickle.dump(self._element_map, f)
 
@@ -129,7 +129,7 @@ class DataMemorySet (DataSet):
         """
         with self._element_map_lock:
             for e in elems:
-                assert isinstance(e, DataElement)
+                assert isinstance(e, DataElement), "Expected DataElement instance, got '%s' instance instead" % type(e)
                 self._element_map[e.uuid()] = e
             self.cache()
 

--- a/python/smqtk/representation/descriptor_element/__init__.py
+++ b/python/smqtk/representation/descriptor_element/__init__.py
@@ -161,6 +161,9 @@ class DescriptorElement (SmqtkRepresentation, plugin.Pluggable):
         return
 
 
+from ._io import *
+
+
 def get_descriptor_element_impls():
     """
     Discover and return Descriptor implementation classes found in the plugin

--- a/python/smqtk/representation/descriptor_element/_io.py
+++ b/python/smqtk/representation/descriptor_element/_io.py
@@ -1,0 +1,110 @@
+import logging
+import multiprocessing
+
+import numpy
+
+from smqtk.utils import SmqtkObject
+
+
+__author__ = 'paul.tunison@kitware.com'
+
+
+__all__ = [
+    'elements_to_matrix',
+]
+
+
+def elements_to_matrix(descr_elements, mat=None, procs=None):
+    """
+    Add to or create a numpy matrix, adding to it the vector data contained in
+    a sequence of DescriptorElement instances using asynchronous processing.
+
+    If ``mat`` is provided, its shape must equal:
+        ( len(descr_elements) , descr_elements[0].size )
+
+    :param descr_elements:
+    :param mat:
+    :param procs:
+
+    :return: Create or input matrix
+
+
+    """
+    log = logging.getLogger(__name__)
+
+    # Special case for in-memory storage of descriptors
+    from smqtk.representation.descriptor_element.local_elements \
+        import DescriptorMemoryElement
+
+    # Create/check matrix
+    if mat is None:
+        mat = numpy.ndarray((len(descr_elements),
+                             descr_elements[0].vector().size),
+                            float)
+    else:
+        assert mat.shape[0] == len(descr_elements)
+        assert mat.shape[1] == descr_elements[0].vector().size
+
+    if procs is None:
+        procs = multiprocessing.cpu_count()
+
+    in_q = multiprocessing.Queue()
+    out_q = multiprocessing.Queue(procs * 2)
+
+    # Workers for async extraction
+    workers = [_ElemVectorExtractor(in_q, out_q) for _ in xrange(procs)]
+
+    async_packets_sent = 0
+    for r, d in enumerate(descr_elements):
+        if isinstance(d, DescriptorMemoryElement):
+            # No loading required, already in memory
+            mat[r] = d.vector()
+        else:
+            in_q.put((r, d))
+            async_packets_sent += 1
+
+    # Collect work from async
+    for _ in xrange(async_packets_sent):
+        r, v = out_q.get()
+        mat[r] = v
+    out_q.close()
+
+    # All work should be exhausted at this point
+    assert in_q.qsize() == 0
+    assert out_q.qsize() == 0
+
+    # Shutdown workers
+    # - Workers should exit upon getting a None packet
+    for _ in workers:
+        # One for each worker
+        in_q.put(None)
+    in_q.close()
+    for w in workers:
+        w.join()
+
+    return mat
+
+
+class _ElemVectorExtractor (SmqtkObject, multiprocessing.Process):
+    """
+    Helper process for extracting DescriptorElement vectors on a separate
+    process. This terminates with a None packet fed to in_q. Otherwise, in_q
+    values are expected to be (row, element) pairs. Tuples of the form
+    (row, vector) are published to the out_q.
+
+    Terminal value: None
+
+    """
+
+    def __init__(self, in_q, out_q):
+        super(_ElemVectorExtractor, self)\
+            .__init__()
+        self.in_q = in_q
+        self.out_q = out_q
+
+    def run(self):
+        packet = self.in_q.get()
+        while packet is not None:
+            row, elem = packet
+            self.out_q.put((row, elem.vector()))
+            packet = self.in_q.get()

--- a/python/smqtk/tests/representation/DataSet/test_MemorySet.py
+++ b/python/smqtk/tests/representation/DataSet/test_MemorySet.py
@@ -11,7 +11,8 @@ class TestDataFileSet (unittest.TestCase):
 
     def test_configuration(self):
         default_config = DataMemorySet.get_default_config()
-        ntools.assert_equal(default_config, {})
+        expected_config = {"file_cache": None}
+        ntools.assert_equal(default_config, expected_config)
 
         inst1 = DataMemorySet.from_config(default_config)
         # idempotency

--- a/python/smqtk/utils/configurable_interface.py
+++ b/python/smqtk/utils/configurable_interface.py
@@ -1,5 +1,6 @@
 import abc
 import inspect
+import types
 
 
 __author__ = "paul.tunison@kitware.com"
@@ -32,19 +33,23 @@ class Configurable (object):
         :rtype: dict
 
         """
-        argspec = inspect.getargspec(cls.__init__)
+        if isinstance(cls.__init__, types.MethodType):
+            argspec = inspect.getargspec(cls.__init__)
 
-        # Ignores potential *args or **kwargs present
-        params = argspec.args[1:]  # skipping ``self`` arg
-        num_params = len(params)
+            # Ignores potential *args or **kwargs present
+            params = argspec.args[1:]  # skipping ``self`` arg
+            num_params = len(params)
 
-        if argspec.defaults:
-            num_defaults = len(argspec.defaults)
-            vals = ((None,) * (num_params - num_defaults) + argspec.defaults)
-        else:
-            vals = (None,) * num_params
+            if argspec.defaults:
+                num_defaults = len(argspec.defaults)
+                vals = ((None,) * (num_params - num_defaults) + argspec.defaults)
+            else:
+                vals = (None,) * num_params
 
-        return dict(zip(params, vals))
+            return dict(zip(params, vals))
+
+        # No constructor explicitly defined on this class
+        return {}
 
     @classmethod
     def from_config(cls, config_dict):

--- a/setup_env.build.sh.in
+++ b/setup_env.build.sh.in
@@ -3,7 +3,8 @@
 #
 # SMQTK system setup script (build version)
 #
-export SMQTK_INSTALL="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SMQTK_SOURCE="@SMQTK_SOURCE_DIR@"
+export SMQTK_INSTALL="@SMQTK_BINARY_DIR@"
 
 export PATH="@SMQTK_SOURCE_DIR@/bin:@SMQTK_BINARY_DIR@/src/frame_extractor/:@SMQTK_BINARY_DIR@/src/cnn_feature_extractor/:@TPL_LOCAL_INSTALL@/bin:$PATH"
 export PYTHONPATH="@SMQTK_SOURCE_DIR@/python:@SMQTK_BINARY_DIR@/python:@TPL_PYTHON_SP@:$PYTHONPATH"


### PR DESCRIPTION
- Added wrapper for CNN descriptor generation executable optionally built in SMQTK
- Added additional scripts used on GPU computation machine for MEMEX
- Added HBase DataElement implementation
- Added async conversion of DescriptorElement instances into a 2D numpy.ndarray
- Fixed Configurable.get_default_config() for sub-classes that don't explicitly implement an __init__ constructor method.
- Fixed bug with libSVM relevancy index to now work with distances less than -1 (e.g. using HIK on CNN vectors)
- Added file cache backing option to DataMemorySet.
- Updated tests
- Added SMQTK_SOURCE env variable export in build-focused setup script