### PR TITLE
File/IQR/Logging Updates

### DIFF
--- a/bin/scripts/iqr_app_model_generation.py
+++ b/bin/scripts/iqr_app_model_generation.py
@@ -35,7 +35,8 @@ __author__ = 'paul.tunison@kitware.com'
 # Setup logging
 #
 if not logging.getLogger().handlers:
-    bin_utils.initialize_logging(logging.getLogger(), logging.INFO)
+    bin_utils.initialize_logging(logging.getLogger(), logging.DEBUG)
+log = logging.getLogger("smqtk.scripts.iqr_app_model_generation")
 
 
 #
@@ -83,10 +84,7 @@ rel_index_config = search_app_iqr_config['rel_index_config']
 
 # Configure DescriptorElementFactory instance, which defines what implementation
 # of DescriptorElement to use for storing generated descriptor vectors below.
-descriptor_elem_factory_config = {
-    'DescriptorMemoryElement': {},
-    'type': 'DescriptorMemoryElement'
-}
+descriptor_elem_factory_config = search_app_iqr_config['descriptor_factory']
 
 
 #

--- a/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_default_imagenet/descriptor.py
@@ -214,6 +214,7 @@ class CaffeDefaultImageNet (DescriptorGenerator):
 
             data_elements[d.uuid()] = d
             descr_elements[d.uuid()] = descr_factory.new_descriptor(self.name, d.uuid())
+        self._log.debug("Given %d data elements", len(data_elements))
 
         # Reduce procs down to the number of elements to process if its smaller
         if len(data_elements) < (procs or multiprocessing.cpu_count()):
@@ -226,6 +227,7 @@ class CaffeDefaultImageNet (DescriptorGenerator):
         for d in descr_elements.itervalues():
             if overwrite or not d.has_vector():
                 key_queue.append(d.uuid())
+        self._log.debug("Elements for processing: %d", len(key_queue))
 
         if key_queue:
             # Split keys into two batches:

--- a/python/smqtk/representation/code_index/__init__.py
+++ b/python/smqtk/representation/code_index/__init__.py
@@ -40,6 +40,16 @@ class CodeIndex (SmqtkRepresentation, plugin.Pluggable):
         """
 
     @abc.abstractmethod
+    def iter_codes(self):
+        """
+        Iterate over code contained in this index in an arbitrary order.
+
+        :return: Generator that yields integer code keys
+        :rtype: collections.Iterator[int|long]
+
+        """
+
+    @abc.abstractmethod
     def add_descriptor(self, code, descriptor):
         """
         Add a descriptor to this index given a matching small-code.

--- a/python/smqtk/representation/code_index/memory.py
+++ b/python/smqtk/representation/code_index/memory.py
@@ -82,6 +82,17 @@ class MemoryCodeIndex (CodeIndex):
         """
         return set(self._table)
 
+    def iter_codes(self):
+        """
+        Iterate over code contained in this index in an arbitrary order.
+
+        :return: Generator that yields integer code keys
+        :rtype: collections.Iterator[int|long]
+
+        """
+        for k in self._table:
+            yield k
+
     def add_descriptor(self, code, descriptor, no_cache=False):
         """
         Add a descriptor to this index given a matching small-code

--- a/python/smqtk/representation/code_index/solr_index.py
+++ b/python/smqtk/representation/code_index/solr_index.py
@@ -168,11 +168,22 @@ class SolrCodeIndex (CodeIndex):
         :return: Set of code integers currently used in this code index.
         :rtype: set[int]
         """
+        return set(self.iter_codes())
+
+    def iter_codes(self):
+        """
+        Iterate over code contained in this index in an arbitrary order.
+
+        :return: Generator that yields integer code keys
+        :rtype: collections.Iterator[int|long]
+
+        """
         r = self.solr.select("%s:%s" % (self.idx_uuid_field, self.uuid),
                              rows=0,
                              facet='true', facet_field=self.code_field)
         val2count = r.facet_counts['facet_fields'][self.code_field]
-        return set(int(k) for k in val2count)
+        for k in val2count:
+            yield int(k)
 
     def _doc_for_code_descr(self, code, descr):
         """

--- a/python/smqtk/representation/data_element/__init__.py
+++ b/python/smqtk/representation/data_element/__init__.py
@@ -1,4 +1,5 @@
 import abc
+from collections import deque
 import hashlib
 import mimetypes
 import os
@@ -52,12 +53,12 @@ class DataElement (SmqtkRepresentation, plugin.Pluggable):
         Clear paths in temp list that don't exist on the system until we
         encounter one that does.
         """
-        exist_found = False
-        while not exist_found and self._temp_filepath_stack:
-            fp = self._temp_filepath_stack.pop()
-            if osp.isfile(fp):
-                self._temp_filepath_stack.append(fp)
-                exist_found = True
+        no_exist_paths = deque()
+        for fp in self._temp_filepath_stack:
+            if not osp.isfile(fp):
+                no_exist_paths.append(fp)
+        for fp in no_exist_paths:
+            self._temp_filepath_stack.remove(fp)
 
     def md5(self):
         """

--- a/python/smqtk/representation/data_set/file_set.py
+++ b/python/smqtk/representation/data_set/file_set.py
@@ -74,7 +74,7 @@ class DataFileSet (DataSet):
                 # if the path doesn't have the configured split chunking value,
                 # it doesn't belong to this data set
                 seg = osp.dirname(osp.relpath(fp, self._root_dir)).split(os.sep)
-                if len(seg) == self._uuid_chunk:
+                if not self._uuid_chunk or len(seg) == self._uuid_chunk:
                     yield fp
 
     def _uuid_from_fp(self, fp):
@@ -84,6 +84,10 @@ class DataFileSet (DataSet):
         """
         Return the containing directory for something with the given UUID value
         """
+        if not self._uuid_chunk:
+            # No sub-directory storage configured
+            return self._root_dir
+
         return osp.join(self._root_dir,
                         *partition_string(uuid, self._uuid_chunk))
 

--- a/python/smqtk/tests/representation/code_index/test_abstractCodeIndex.py
+++ b/python/smqtk/tests/representation/code_index/test_abstractCodeIndex.py
@@ -30,6 +30,7 @@ class DummyCodeIndex (CodeIndex):
     add_descriptor = mock.Mock()
     add_many_descriptors = mock.Mock()
     codes = mock.Mock()
+    iter_codes = mock.Mock()
     count = mock.Mock()
     clear = mock.Mock()
     get_config = mock.Mock()

--- a/python/smqtk/web/search_app/modules/iqr/iqr_search.py
+++ b/python/smqtk/web/search_app/modules/iqr/iqr_search.py
@@ -221,6 +221,7 @@ class IqrSearch (flask.Blueprint, Configurable):
 
         # Cache mapping of written static files for data elements
         self._static_cache = {}
+        self._static_cache_element = {}
 
         #
         # Routing
@@ -317,6 +318,7 @@ class IqrSearch (flask.Blueprint, Configurable):
                 if de.uuid() not in self._static_cache:
                     self._static_cache[de.uuid()] = \
                         de.write_temp(self._static_data_dir)
+                    self._static_cache_element[de.uuid()] = de
 
                 # Need to format links by transforming the generated paths to
                 # something usable by webpage:


### PR DESCRIPTION
- Added various amounts of new logging.
- Now read DescriptorElementFactory config from IQR-app configuration when training for app.
- Updated function of repeated IQR-app working index initialization to only additionally query for neighbors to positives added since the last initialization in the same session. Cache cleared on session reset. This means we only add to the session working session when re-initializing.
- Added to ``DataElement.write_temp()`` to clear temp files that don't exist on dist before checking whether it should write a temp file. This adds robustness to files disappearing on disk during run-time.
- Fixed DataFileSet file element path resolution when ``uuid_chunk`` is 0 or None or other False-evaluating value.
- Fixed an issue where clicking on an image to open in a separate window resulted in a 404. This was because the DataSet implementation being used created ephemeral DataElements, whose temporary files were removed from disk 