### PR TITLE
Fix smqtk python cmake install code

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,13 +1,5 @@
 # Installation
-install(DIRECTORY EventContentDescriptor
-  DESTINATION "${python_site_packages}"
-  )
-
 install(DIRECTORY smqtk
   DESTINATION "${python_site_packages}"
   USE_SOURCE_PERMISSIONS
-  )
-
-install(DIRECTORY Utils
-  DESTINATION "${python_site_packages}"
   )


### PR DESCRIPTION
Removed install command for directories not there anymore. Tested full build and install on a fedora 23 box, which now works (I see little reason why it wouldn't work elsewhere, but let me know).