### PR TITLE
Dev/readthedocsfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.pyc
 *.pyo
 
+# Sphinx compile files
+/docs/_build/
+
 # ColorDescriptor generated errors log file
 errors.log
 

--- a/docs/algorithmmodels.rst
+++ b/docs/algorithmmodels.rst
@@ -109,6 +109,7 @@ Currently, we do not package an implementation that requires additional model cr
 The general pattern for ``RelevancyIndex`` instance index model generation:
 
 .. code-block:: python
+
     descriptors = [...]  # some number of descriptors to index
 
     index = RelevancyIndexImpl(...)

--- a/docs/algorithms.rst
+++ b/docs/algorithms.rst
@@ -4,5 +4,5 @@ Algorithms
 .. toctree::
    :maxdepth: 3
 
-    algorithminterfaces
-    algorithmmodels
+   algorithminterfaces
+   algorithmmodels

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -7,16 +7,19 @@ Dependencies
 In order to provide basic functionality:
 
 * Build SMQTK via CMAKE.
- * Currently, a naive CMake configuration (no modifications to options) is acceptable for basic functionality.
+  * Currently, a naive CMake configuration (no modifications to options) is acceptable for basic functionality.
 * Install python packages detailed in the :file:`requirements.*.txt` files.
 
 In order to run provided SMQTKSearchApp web application, the following are additionally required:
-
+ 
 * MongoDB
- * MongoDB is required for the Web application for session storage.
-   This allows the Flask application API to modify session contents when within AJAX routines.
-   This required for asynchronous user-session state interaction/modification.
- * This is not a permanent requirement as other mediums can be used for this purpose, however they would need implementation.
+  * MongoDB is required for the Web application for session storage.
+
+    This allows the Flask application API to modify session contents when within AJAX routines.
+
+    This required for asynchronous user-session state interaction/modification.
+
+  * This is not a permanent requirement as other mediums can be used for this purpose, however they would need implementation.
 
 Installing Python dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -38,6 +41,7 @@ While conda is generally considered the preferred method of acquiring python dep
 
 Installing with Conda and Pip
 """""""""""""""""""""""""""""
+
 The three-step python dependency installation using both conda and pip will look like the following:
 
 .. prompt:: bash
@@ -61,7 +65,7 @@ If installation of python dependencies via pip only is desired, or if local comp
 Where the :file:requirements.docs.*.txt arguments are only needed if you intend to build the SMQTK documentation.
 
 NumPy and SciPy
-+++++++++++++++
+^^^^^^^^^^^^^^^
 
 If installing NumPy and SciPy via pip, it may be useful or required to install BLAS or LAPACK libraries for certain functionality and efficiency.
 
@@ -75,8 +79,10 @@ This may be because a descriptor required additional libraries or tools on the s
 For example, the ColorDescriptor implementation required a 3rd party tool to downloaded and setup.
 
 * ColorDescriptor
- * For CSIFT, TCH, etc. feature descriptors.
-   * http://koen.me/research/colordescriptors/
+  * For CSIFT, TCH, etc. feature descriptors.
+  
+    * http://koen.me/research/colordescriptors/
+
  * After unpacking the downloaded ZIP archive, add the directory it was extracted to to the PYTHONPATH so the DescriptorIO.py module can be accessed and used within the SMQTK library.
  * Note that a license is required for commercial use (See the koen.me webpage).
 
@@ -106,7 +112,7 @@ Optionally, the `ccmake` command line utility, or the GUI version, may be run in
 Currently, the selection is very minimal, but may be expanded over time.
  
 Example
--------
+"""""""
 
 .. prompt:: bash
 
@@ -148,7 +154,7 @@ Will show the other documentation formats that may be available (although be awa
 .. _reStructuredText: http://docutils.sourceforge.net/rst.html
 
 Live Preview
-++++++++++++
+^^^^^^^^^^^^
 
 While writing documentation in a mark up format such as ``reStructuredText`` it is very helpful to be able to preview the formated version of the text.  While it is possible to 
 simply run the ``make html`` command periodically, a more seamless version of this is available.  Within the :file:`docs` directory is a small Python script called 

--- a/docs/building.rst
+++ b/docs/building.rst
@@ -11,7 +11,7 @@ In order to provide basic functionality:
 * Install python packages detailed in the :file:`requirements.*.txt` files.
 
 In order to run provided SMQTKSearchApp web application, the following are additionally required:
- 
+
 * MongoDB
   * MongoDB is required for the Web application for session storage.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,12 +15,31 @@
 import sys
 import os
 import shlex
+from mock import Mock as MagicMock
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../python'))
 sys.path.insert(0, os.path.abspath('../bin'))
+ 
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return Mock()
+ 
+MOCK_MODULES = [ 'numpy', 
+    'numpy.core', 
+    'numpy.core.multiarray', 
+    'numpy.matrixlib', 
+    'numpy.matrixlib.defmatrix', 
+    'PIL',
+    'PIL.Image', 
+    'imageio',
+    'pymongo' ]
+
+
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,19 +22,19 @@ from mock import Mock as MagicMock
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('../python'))
 sys.path.insert(0, os.path.abspath('../bin'))
- 
+
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):
             return Mock()
- 
-MOCK_MODULES = [ 'numpy', 
-    'numpy.core', 
-    'numpy.core.multiarray', 
-    'numpy.matrixlib', 
-    'numpy.matrixlib.defmatrix', 
+
+MOCK_MODULES = [ 'numpy',
+    'numpy.core',
+    'numpy.core.multiarray',
+    'numpy.matrixlib',
+    'numpy.matrixlib.defmatrix',
     'PIL',
-    'PIL.Image', 
+    'PIL.Image',
     'imageio',
     'pymongo' ]
 
@@ -165,7 +165,7 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/dataabstraction.rst
+++ b/docs/dataabstraction.rst
@@ -35,7 +35,7 @@ DataSet
 
 .. automodule:: smqtk.representation.data_set
    :members:
-.. autoclass:: smqtk.representation.data_set.Dataset
+.. autoclass:: smqtk.representation.data_set.DataSet
    :members:
 
 DescriptorElement

--- a/docs/readthedocs-reqs.txt
+++ b/docs/readthedocs-reqs.txt
@@ -1,0 +1,10 @@
+sphinx
+sphinx_rtd_theme
+sphinx-argparse
+sphinx-prompt
+flask
+flask-login
+flask-basicauth
+requests
+mock
+

--- a/docs/sphinx_server.py
+++ b/docs/sphinx_server.py
@@ -14,4 +14,5 @@ livereload_: https://pypi.python.org/pypi/livereload
 from livereload import Server, shell
 server = Server()
 server.watch('*.rst', shell('make html', cwd='.'))
+server.watch('conf.py', shell('make html', cwd='.'))
 server.serve(root='_build/html')

--- a/python/smqtk/web/descriptor_service/__init__.py
+++ b/python/smqtk/web/descriptor_service/__init__.py
@@ -33,19 +33,21 @@ class DescriptorServiceServer (SmqtkWebApp):
     Computes the requested descriptor for the given file and returns that via
     a JSON structure.
 
-    Standard return JSON:
-    {
-        "success": <bool>,
-        "descriptor": [ <float>, ... ]
-        "message": <string>,
-        "reference_uri": <uri>
-    }
+    Standard return JSON::
 
-    # Additional Configuration
+        {
+            "success": <bool>,
+            "descriptor": [ <float>, ... ]
+            "message": <string>,
+            "reference_uri": <uri>
+        }
 
-    ## Environment variable hook
-    We will look for an environment variable `DescriptorService_CONFIG` for a
-    string file path to an additional JSON configuration file to consider.
+    Additional Configuration
+    
+
+   
+    .. note:: We will look for an environment variable `DescriptorService_CONFIG` for a
+              string file path to an additional JSON configuration file to consider.
 
     """
 
@@ -130,7 +132,8 @@ class DescriptorServiceServer (SmqtkWebApp):
             Compute descriptors over the specified content for all generators
             that function over the data's content type.
 
-            # JSON Return format
+            JSON Return format::
+
                 {
                     "success": <bool>
 
@@ -185,29 +188,38 @@ class DescriptorServiceServer (SmqtkWebApp):
         @self.route("/<string:descriptor_label>/<path:uri>")
         def compute_descriptor(descriptor_label, uri):
             """
-            # Data modes for upload/use
+
+            Data modes for upload/use::
+
                 - local filepath
                 - base64
                 - http/s URL
 
             The following sub-sections detail how different URI's can be used.
 
-            ## Local Filepath
+            Local Filepath
+            --------------
+
             The URI string must be prefixed with ``file://``, followed by the
             full path to the data file to describe.
 
-            ## Base 64 data
+            Base 64 data
+            ------------
+
             The URI string must be prefixed with "base64://", followed by the
             base64 encoded string. This mode also requires an additional
             ``?content_type=`` to provide data content type information. This
             mode saves the encoded data to temporary file for processing.
 
-            ## HTTP/S address
+            HTTP/S address
+            --------------
+
             This is the default mode when the URI prefix is none of the above.
             This uses the requests module to locally download a data file
             for processing.
 
-            # JSON Return format
+            JSON Return format::
+
                 {
                     "success": <bool>
 

--- a/python/smqtk/web/search_app/__init__.py
+++ b/python/smqtk/web/search_app/__init__.py
@@ -128,10 +128,11 @@ class IqrSearchApp (SmqtkWebApp):
         in order to allow proper construction and rendering of navigation bar
         content.
 
-        For example, when returning a flask.render_template() call:
-        >> ret = {"things": "and stuff"}
-        >> ret.update(smqtk_search_app.nav_bar_content())
-        >> return flask.render_template("some_template.tmpl", **ret)
+        For example, when returning a flask.render_template() call::
+
+            ret = {"things": "and stuff"}
+            ret.update(smqtk_search_app.nav_bar_content())
+            return flask.render_template("some_template.tmpl", **ret)
 
         :return: Dictionary of content required for proper display of the
             navigation bar. Contains keys of module names and values of module

--- a/requirements.docs.pip.txt
+++ b/requirements.docs.pip.txt
@@ -1,4 +1,4 @@
 livereload
 sphinx-argparse
 sphinx-prompt
-sphinx-rtd-theme
+mock


### PR DESCRIPTION
Syntax fixes that allow Spinx to build and changes to the Sphinx configuration that mock away dependencies so that the readthedocs.org build environment can import modules to extract documentation.