### PR TITLE
IQR session supervised classifier trainer

### DIFF
--- a/TPL/libsvm-3.1-custom/svm.cpp
+++ b/TPL/libsvm-3.1-custom/svm.cpp
@@ -73,7 +73,7 @@ public:
   // return some position p where [p,len) need to be filled
   // (p >= len if nothing needs to be filled)
   int get_data(const int index, Qfloat **data, int len);
-  void swap_index(int i, int j);  
+  void swap_index(int i, int j);
 private:
   int l;
   long int size;
@@ -230,7 +230,7 @@ private:
   static double histogram_intersection(const svm_node *px, const svm_node *py);
   static double nmi(const svm_node *px, const svm_node *py);
   static float entropy(float *vec, int elements);
-  
+
   double kernel_histogram(int i, int j) const
   {
     return histogram_intersection(x[i],x[j]);
@@ -325,7 +325,7 @@ double Kernel::dot(const svm_node *px, const svm_node *py)
         ++py;
       else
         ++px;
-    }     
+    }
   }
   return sum;
 }
@@ -350,7 +350,7 @@ double Kernel::histogram_intersection(const svm_node *px, const svm_node *py)
         ++py;
       else
         ++px;
-    }     
+    }
   }
 //  printf("histogram intersection %f\n",sum);
   return sum;
@@ -362,7 +362,7 @@ double Kernel::nmi(const svm_node *px, const svm_node *py)
   double sumy = 0;
   int scale= 2000;
   int scale2 = scale;
-  
+
   std::vector<double> vx;
   std::vector<double> vy;
 
@@ -376,7 +376,7 @@ double Kernel::nmi(const svm_node *px, const svm_node *py)
       if( fabs(px->value - py->value) > 1e-10 )
         diff=true;
 //      printf("%f \t %f\n", px->value, py->value);
-      
+
       sumx += px->value;
       sumy += py->value;
       ++px;
@@ -388,14 +388,14 @@ double Kernel::nmi(const svm_node *px, const svm_node *py)
         ++py;
       else
         ++px;
-    }     
+    }
   }
   printf("Normalized mutual information %g\t%g\n",sumx, sumy);
 //  printf("len(vx) = %d \t len(vy) = %d \n", vx.size(), vy.size());
-  
+
   sumx = (float) (scale-1) / sumx;
   sumy = (float) (scale-1) / sumy;
-  
+
   float *probx = new float[scale2];
   memset( probx, 0, sizeof(float)*scale2 );
 
@@ -419,7 +419,7 @@ double Kernel::nmi(const svm_node *px, const svm_node *py)
   if(diff)
     for(int i=0; i<scale; i++)
       printf("%d %d\n", (int)probx[i], (int)proby[i]);
-  
+
   float hx = entropy(probx, scale);
 //  printf("hx=%f\n", hx);
   float hy = entropy(proby, scale);
@@ -429,11 +429,11 @@ double Kernel::nmi(const svm_node *px, const svm_node *py)
   double nmi = (hx+hy) / hxy - 1;
   printf("nmi=%f \t hx=%f \t hy=%f \t hxy=%f \n", nmi, hx, hy, hxy);
 
-  
+
   delete [] probx;
   delete [] proby;
   delete [] probxy;
-  
+
   return nmi;
 }
 
@@ -477,7 +477,7 @@ double Kernel::k_function(const svm_node *x, const svm_node *y,
         else
         {
           if(x->index > y->index)
-          { 
+          {
             sum += y->value * y->value;
             ++y;
           }
@@ -500,7 +500,7 @@ double Kernel::k_function(const svm_node *x, const svm_node *y,
         sum += y->value * y->value;
         ++y;
       }
-      
+
       return exp(-param.gamma*sum);
     }
     case SIGMOID:
@@ -508,7 +508,7 @@ double Kernel::k_function(const svm_node *x, const svm_node *y,
     case PRECOMPUTED:  //x: test (validation), y: SV
       return x[(int)(y->value)].value;
     default:
-      return 0;  // Unreachable 
+      return 0;  // Unreachable
   }
 }
 
@@ -584,7 +584,7 @@ protected:
   virtual double calculate_rho();
   virtual void do_shrinking();
 private:
-  bool be_shrunk(int i, double Gmax1, double Gmax2);  
+  bool be_shrunk(int i, double Gmax1, double Gmax2);
 };
 
 void Solver::swap_index(int i, int j)
@@ -724,11 +724,11 @@ void Solver::Solve(int l, const QMatrix& Q, const double *p_, const schar *y_,
       else
         counter = 1;  // do shrinking next iteration
     }
-    
+
     ++iter;
 
     // update alpha[i] and alpha[j], handle bounds carefully
-    
+
     const Qfloat *Q_i = Q.get_Q(i,active_size);
     const Qfloat *Q_j = Q.get_Q(j,active_size);
 
@@ -747,7 +747,7 @@ void Solver::Solve(int l, const QMatrix& Q, const double *p_, const schar *y_,
       double diff = alpha[i] - alpha[j];
       alpha[i] += delta;
       alpha[j] += delta;
-      
+
       if(diff > 0)
       {
         if(alpha[j] < 0)
@@ -829,7 +829,7 @@ void Solver::Solve(int l, const QMatrix& Q, const double *p_, const schar *y_,
 
     double delta_alpha_i = alpha[i] - old_alpha_i;
     double delta_alpha_j = alpha[j] - old_alpha_j;
-    
+
     for(int k=0;k<active_size;k++)
     {
       G[k] += Q_i[k]*delta_alpha_i + Q_j[k]*delta_alpha_j;
@@ -917,7 +917,7 @@ int Solver::select_working_set(int &out_i, int &out_j)
   // j: minimizes the decrease of obj value
   //    (if quadratic coefficeint <= 0, replace it with tau)
   //    -y_j*grad(f)_j < -y_i*grad(f)_i, j in I_low(\alpha)
-  
+
   double Gmax = -INF;
   double Gmax2 = -INF;
   int Gmax_idx = -1;
@@ -925,7 +925,7 @@ int Solver::select_working_set(int &out_i, int &out_j)
   double obj_diff_min = INF;
 
   for(int t=0;t<active_size;t++)
-    if(y[t]==+1)  
+    if(y[t]==+1)
     {
       if(!is_upper_bound(t))
         if(-G[t] >= Gmax)
@@ -960,7 +960,7 @@ int Solver::select_working_set(int &out_i, int &out_j)
           Gmax2 = G[j];
         if (grad_diff > 0)
         {
-          double obj_diff; 
+          double obj_diff;
           double quad_coef = QD[i]+QD[j]-2.0*y[i]*Q_i[j];
           if (quad_coef > 0)
             obj_diff = -(grad_diff*grad_diff)/quad_coef;
@@ -984,7 +984,7 @@ int Solver::select_working_set(int &out_i, int &out_j)
           Gmax2 = -G[j];
         if (grad_diff > 0)
         {
-          double obj_diff; 
+          double obj_diff;
           double quad_coef = QD[i]+QD[j]+2.0*y[i]*Q_i[j];
           if (quad_coef > 0)
             obj_diff = -(grad_diff*grad_diff)/quad_coef;
@@ -1022,7 +1022,7 @@ bool Solver::be_shrunk(int i, double Gmax1, double Gmax2)
   {
     if(y[i]==+1)
       return(G[i] > Gmax2);
-    else  
+    else
       return(G[i] > Gmax1);
   }
   else
@@ -1038,27 +1038,27 @@ void Solver::do_shrinking()
   // find maximal violating pair first
   for(i=0;i<active_size;i++)
   {
-    if(y[i]==+1)  
+    if(y[i]==+1)
     {
-      if(!is_upper_bound(i))  
+      if(!is_upper_bound(i))
       {
         if(-G[i] >= Gmax1)
           Gmax1 = -G[i];
       }
-      if(!is_lower_bound(i))  
+      if(!is_lower_bound(i))
       {
         if(G[i] >= Gmax2)
           Gmax2 = G[i];
       }
     }
-    else  
+    else
     {
-      if(!is_upper_bound(i))  
+      if(!is_upper_bound(i))
       {
         if(-G[i] >= Gmax2)
           Gmax2 = -G[i];
       }
-      if(!is_lower_bound(i))  
+      if(!is_lower_bound(i))
       {
         if(G[i] >= Gmax1)
           Gmax1 = G[i];
@@ -1066,7 +1066,7 @@ void Solver::do_shrinking()
     }
   }
 
-  if(unshrink == false && Gmax1 + Gmax2 <= eps*10) 
+  if(unshrink == false && Gmax1 + Gmax2 <= eps*10)
   {
     unshrink = true;
     reconstruct_gradient();
@@ -1205,14 +1205,14 @@ int Solver_NU::select_working_set(int &out_i, int &out_j)
   {
     if(y[j]==+1)
     {
-      if (!is_lower_bound(j)) 
+      if (!is_lower_bound(j))
       {
         double grad_diff=Gmaxp+G[j];
         if (G[j] >= Gmaxp2)
           Gmaxp2 = G[j];
         if (grad_diff > 0)
         {
-          double obj_diff; 
+          double obj_diff;
           double quad_coef = QD[ip]+QD[j]-2*Q_ip[j];
           if (quad_coef > 0)
             obj_diff = -(grad_diff*grad_diff)/quad_coef;
@@ -1236,7 +1236,7 @@ int Solver_NU::select_working_set(int &out_i, int &out_j)
           Gmaxn2 = -G[j];
         if (grad_diff > 0)
         {
-          double obj_diff; 
+          double obj_diff;
           double quad_coef = QD[in]+QD[j]-2*Q_in[j];
           if (quad_coef > 0)
             obj_diff = -(grad_diff*grad_diff)/quad_coef;
@@ -1271,14 +1271,14 @@ bool Solver_NU::be_shrunk(int i, double Gmax1, double Gmax2, double Gmax3, doubl
   {
     if(y[i]==+1)
       return(-G[i] > Gmax1);
-    else  
+    else
       return(-G[i] > Gmax4);
   }
   else if(is_lower_bound(i))
   {
     if(y[i]==+1)
       return(G[i] > Gmax2);
-    else  
+    else
       return(G[i] > Gmax3);
   }
   else
@@ -1307,14 +1307,14 @@ void Solver_NU::do_shrinking()
     if(!is_lower_bound(i))
     {
       if(y[i]==+1)
-      { 
+      {
         if(G[i] > Gmax2) Gmax2 = G[i];
       }
       else  if(G[i] > Gmax3) Gmax3 = G[i];
     }
   }
 
-  if(unshrink == false && max(Gmax1+Gmax2,Gmax3+Gmax4) <= eps*10) 
+  if(unshrink == false && max(Gmax1+Gmax2,Gmax3+Gmax4) <= eps*10)
   {
     unshrink = true;
     reconstruct_gradient();
@@ -1377,12 +1377,12 @@ double Solver_NU::calculate_rho()
     r1 = sum_free1/nr_free1;
   else
     r1 = (ub1+lb1)/2;
-  
+
   if(nr_free2 > 0)
     r2 = sum_free2/nr_free2;
   else
     r2 = (ub2+lb2)/2;
-  
+
   si->r = (r1+r2)/2;
   return (r1-r2)/2;
 }
@@ -1391,7 +1391,7 @@ double Solver_NU::calculate_rho()
 // Q matrices for various formulations
 //
 class SVC_Q: public Kernel
-{ 
+{
 public:
   SVC_Q(const svm_problem& prob, const svm_parameter& param, const schar *y_)
   :Kernel(prob.l, prob.x, param)
@@ -1402,7 +1402,7 @@ public:
     for(int i=0;i<prob.l;i++)
       QD[i] = (this->*kernel_function)(i,i);
   }
-  
+
   Qfloat *get_Q(int i, int len) const
   {
     Qfloat *data;
@@ -1451,7 +1451,7 @@ public:
     for(int i=0;i<prob.l;i++)
       QD[i] = (this->*kernel_function)(i,i);
   }
-  
+
   Qfloat *get_Q(int i, int len) const
   {
     Qfloat *data;
@@ -1487,7 +1487,7 @@ private:
 };
 
 class SVR_Q: public Kernel
-{ 
+{
 public:
   SVR_Q(const svm_problem& prob, const svm_parameter& param)
   :Kernel(prob.l, prob.x, param)
@@ -1517,7 +1517,7 @@ public:
     swap(index[i],index[j]);
     swap(QD[i],QD[j]);
   }
-  
+
   Qfloat *get_Q(int i, int len) const
   {
     Qfloat *data;
@@ -1768,7 +1768,7 @@ static void solve_nu_svr(
 struct decision_function
 {
   double *alpha;
-  double rho; 
+  double rho;
 };
 
 static decision_function svm_train_one(
@@ -1830,7 +1830,7 @@ static decision_function svm_train_one(
 
 // Platt's binary SVM Probablistic Output: an improvement from Lin et al.
 static void sigmoid_train(
-  int l, const double *dec_values, const double *labels, 
+  int l, const double *dec_values, const double *labels,
   double& A, double& B)
 {
   double prior1=0, prior0 = 0;
@@ -1839,7 +1839,7 @@ static void sigmoid_train(
   for (i=0;i<l;i++)
     if (labels[i] > 0) prior1+=1;
     else prior0+=1;
-  
+
   int max_iter=100; // Maximal number of iterations
   double min_step=1e-10;  // Minimal step taken in line search
   double sigma=1e-12; // For numerically strict PD of Hessian
@@ -1849,8 +1849,8 @@ static void sigmoid_train(
   double *t=Malloc(double,l);
   double fApB,p,q,h11,h22,h21,g1,g2,det,dA,dB,gd,stepsize;
   double newA,newB,newf,d1,d2;
-  int iter; 
-  
+  int iter;
+
   // Initial Point and Initial Fun Value
   A=0.0; B=log((prior0+1.0)/(prior1+1.0));
   double fval = 0.0;
@@ -1960,7 +1960,7 @@ static void multiclass_probability(int k, double **r, double *p)
   double **Q=Malloc(double *,k);
   double *Qp=Malloc(double,k);
   double pQp, eps=0.005/k;
-  
+
   for (t=0;t<k;t++)
   {
     p[t]=1.0/k;  // Valid if k = 1
@@ -1996,7 +1996,7 @@ static void multiclass_probability(int k, double **r, double *p)
         max_error=error;
     }
     if (max_error<eps) break;
-    
+
     for (t=0;t<k;t++)
     {
       double diff=(-Qp[t]+pQp)/Q[t][t];
@@ -2043,7 +2043,7 @@ static void svm_binary_svc_probability(
     subprob.l = prob->l-(end-begin);
     subprob.x = Malloc(struct svm_node*,subprob.l);
     subprob.y = Malloc(double,subprob.l);
-      
+
     k=0;
     for(j=0;j<begin;j++)
     {
@@ -2088,22 +2088,22 @@ static void svm_binary_svc_probability(
       struct svm_model *submodel = svm_train(&subprob,&subparam);
       for(j=begin;j<end;j++)
       {
-        svm_predict_values(submodel,prob->x[perm[j]],&(dec_values[perm[j]])); 
+        svm_predict_values(submodel,prob->x[perm[j]],&(dec_values[perm[j]]));
         // ensure +1 -1 order; reason not using CV subroutine
         dec_values[perm[j]] *= submodel->label[0];
-      }   
+      }
       svm_free_and_destroy_model(&submodel);
       svm_destroy_param(&subparam);
     }
     free(subprob.x);
     free(subprob.y);
-  }   
+  }
   sigmoid_train(prob->l,dec_values,prob->y,probA,probB);
   free(dec_values);
   free(perm);
 }
 
-// Return parameter of a Laplace distribution 
+// Return parameter of a Laplace distribution
 static double svm_svr_probability(
   const svm_problem *prob, const svm_parameter *param)
 {
@@ -2119,15 +2119,15 @@ static double svm_svr_probability(
   {
     ymv[i]=prob->y[i]-ymv[i];
     mae += fabs(ymv[i]);
-  }   
+  }
   mae /= prob->l;
   double std=sqrt(2*mae*mae);
   int count=0;
   mae=0;
   for(i=0;i<prob->l;i++)
-    if (fabs(ymv[i]) > 5*std) 
+    if (fabs(ymv[i]) > 5*std)
       count=count+1;
-    else 
+    else
       mae+=fabs(ymv[i]);
   mae /= (prob->l-count);
   info("Prob. model for test data: target value = predicted value + z,\nz: Laplace distribution e^(-|z|/sigma)/(2sigma),sigma= %g\n",mae);
@@ -2145,7 +2145,7 @@ static void svm_group_classes(const svm_problem *prob, int *nr_class_ret, int **
   int nr_class = 0;
   int *label = Malloc(int,max_nr_class);
   int *count = Malloc(int,max_nr_class);
-  int *data_label = Malloc(int,l);  
+  int *data_label = Malloc(int,l);
   int i;
 
   for(i=0;i<l;i++)
@@ -2215,7 +2215,7 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
     model->probA = NULL; model->probB = NULL;
     model->sv_coef = Malloc(double *,1);
 
-    if(param->probability && 
+    if(param->probability &&
        (param->svm_type == EPSILON_SVR ||
         param->svm_type == NU_SVR))
     {
@@ -2241,7 +2241,7 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
         model->SV[j] = prob->x[i];
         model->sv_coef[0][j] = f.alpha[i];
         ++j;
-      }   
+      }
 
     free(f.alpha);
   }
@@ -2256,7 +2256,7 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
     int *perm = Malloc(int,l);
 
     // group training data of the same class
-    svm_group_classes(prob,&nr_class,&label,&start,&count,perm);    
+    svm_group_classes(prob,&nr_class,&label,&start,&count,perm);
     svm_node **x = Malloc(svm_node *,l);
     int i;
     for(i=0;i<l;i++)
@@ -2268,7 +2268,7 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
     for(i=0;i<nr_class;i++)
       weighted_C[i] = param->C;
     for(i=0;i<param->nr_weight;i++)
-    { 
+    {
       int j;
       for(j=0;j<nr_class;j++)
         if(param->weight_label[i] == label[j])
@@ -2280,7 +2280,7 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
     }
 
     // train k*(k-1)/2 models
-    
+
     bool *nonzero = Malloc(bool,l);
     for(i=0;i<l;i++)
       nonzero[i] = false;
@@ -2333,11 +2333,11 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
     // build output
 
     model->nr_class = nr_class;
-    
+
     model->label = Malloc(int,nr_class);
     for(i=0;i<nr_class;i++)
       model->label[i] = label[i];
-    
+
     model->rho = Malloc(double,nr_class*(nr_class-1)/2);
     for(i=0;i<nr_class*(nr_class-1)/2;i++)
       model->rho[i] = f[i].rho;
@@ -2366,14 +2366,14 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
       int nSV = 0;
       for(int j=0;j<count[i];j++)
         if(nonzero[start[i]+j])
-        { 
+        {
           ++nSV;
           ++total_sv;
         }
       model->nSV[i] = nSV;
       nz_count[i] = nSV;
     }
-    
+
     info("Total nSV = %d\n",total_sv);
 
     model->l = total_sv;
@@ -2403,7 +2403,7 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
         int sj = start[j];
         int ci = count[i];
         int cj = count[j];
-        
+
         int q = nz_start[i];
         int k;
         for(k=0;k<ci;k++)
@@ -2415,7 +2415,7 @@ svm_model *svm_train(const svm_problem *prob, const svm_parameter *param)
             model->sv_coef[i][q++] = f[p].alpha[ci+k];
         ++p;
       }
-    
+
     free(label);
     free(probA);
     free(probB);
@@ -2459,7 +2459,7 @@ void svm_cross_validation(const svm_problem *prob, const svm_parameter *param, i
     int *index = Malloc(int,l);
     for(i=0;i<l;i++)
       index[i]=perm[i];
-    for (c=0; c<nr_class; c++) 
+    for (c=0; c<nr_class; c++)
       for(i=0;i<count[c];i++)
       {
         int j = i+rand()%(count[c]-i);
@@ -2488,9 +2488,9 @@ void svm_cross_validation(const svm_problem *prob, const svm_parameter *param, i
     fold_start[0]=0;
     for (i=1;i<=nr_fold;i++)
       fold_start[i] = fold_start[i-1]+fold_count[i-1];
-    free(start);  
+    free(start);
     free(label);
-    free(count);  
+    free(count);
     free(index);
     free(fold_count);
   }
@@ -2516,7 +2516,7 @@ void svm_cross_validation(const svm_problem *prob, const svm_parameter *param, i
     subprob.l = l-(end-begin);
     subprob.x = Malloc(struct svm_node*,subprob.l);
     subprob.y = Malloc(double,subprob.l);
-      
+
     k=0;
     for(j=0;j<begin;j++)
     {
@@ -2531,13 +2531,13 @@ void svm_cross_validation(const svm_problem *prob, const svm_parameter *param, i
       ++k;
     }
     struct svm_model *submodel = svm_train(&subprob,param);
-    if(param->probability && 
+    if(param->probability &&
        (param->svm_type == C_SVC || param->svm_type == NU_SVC))
     {
       double *prob_estimates=Malloc(double,svm_get_nr_class(submodel));
       for(j=begin;j<end;j++)
         target[perm[j]] = svm_predict_probability(submodel,prob->x[perm[j]],prob_estimates);
-      free(prob_estimates);     
+      free(prob_estimates);
     }
     else
       for(j=begin;j<end;j++)
@@ -2545,9 +2545,9 @@ void svm_cross_validation(const svm_problem *prob, const svm_parameter *param, i
     svm_free_and_destroy_model(&submodel);
     free(subprob.x);
     free(subprob.y);
-  }   
+  }
   free(fold_start);
-  free(perm); 
+  free(perm);
 }
 
 
@@ -2603,7 +2603,7 @@ double svm_predict_values(const svm_model *model, const svm_node *x, double* dec
     int i;
     int nr_class = model->nr_class;
     int l = model->l;
-    
+
     double *kvalue = Malloc(double,l);
     for(i=0;i<l;i++)
       kvalue[i] = Kernel::k_function(x,model->SV[i],model->param);
@@ -2626,7 +2626,7 @@ double svm_predict_values(const svm_model *model, const svm_node *x, double* dec
         int sj = start[j];
         int ci = model->nSV[i];
         int cj = model->nSV[j];
-        
+
         int k;
         double *coef1 = model->sv_coef[j-1];
         double *coef2 = model->sv_coef[i];
@@ -2664,7 +2664,7 @@ double svm_predict(const svm_model *model, const svm_node *x)
      model->param.svm_type == EPSILON_SVR ||
      model->param.svm_type == NU_SVR)
     dec_values = Malloc(double, 1);
-  else 
+  else
     dec_values = Malloc(double, nr_class*(nr_class-1)/2);
   double pred_result = svm_predict_values(model, x, dec_values);
   free(dec_values);
@@ -2703,10 +2703,10 @@ double svm_predict_probability(
     for(i=0;i<nr_class;i++)
       free(pairwise_prob[i]);
     free(dec_values);
-    free(pairwise_prob);       
+    free(pairwise_prob);
     return model->label[prob_max_idx];
   }
-  else 
+  else
     return svm_predict(model, x);
 }
 
@@ -2743,14 +2743,14 @@ int svm_save_model(const char *model_file_name, const svm_model *model)
   int l = model->l;
   fprintf(fp, "nr_class %d\n", nr_class);
   fprintf(fp, "total_sv %d\n",l);
-  
+
   {
     fprintf(fp, "rho");
     for(int i=0;i<nr_class*(nr_class-1)/2;i++)
       fprintf(fp," %g",model->rho[i]);
     fprintf(fp, "\n");
   }
-  
+
   if(model->label)
   {
     fprintf(fp, "label");
@@ -2804,54 +2804,6 @@ int svm_save_model(const char *model_file_name, const svm_model *model)
     fprintf(fp, "\n");
   }
 
-  // ( Z. Sun )
-  if( model->nr_class == 2 )
-  {
-    // write out linear SVM model
-    char str[2048];    
-    sprintf(str,"%s_libsvm", model_file_name);
-//    printf("%s\n", str);
-    
-    int var_count = 0;
-    svm_node* p = model->SV[0];
-    while( p->index != -1 )
-    {
-      ++p;
-      ++var_count;
-    }
-//    printf("var_count = %d \n", var_count);
-
-    FILE *fp = fopen(str,"w");
-    if( fp != NULL )
-    {
-      double* s = new double [var_count];
-      for(int j=0; j<var_count; j++)
-        s[j] = 0.0;
-      
-      for(int k=0; k<model->l; k++)
-      {
-        svm_node* onesv = model->SV[k];
-        double w = model->sv_coef[0][k];
-//        printf("%f ", w);
-        while( onesv->index != -1 )
-        {
-          s[onesv->index-1] += onesv->value * w;
-//          printf("%d:%f ", onesv->index,onesv->value);
-          onesv++;
-        }
-//        printf("\n");
-      }
-      
-      for(int k=0; k<var_count; k++)
-      {
-        fprintf(fp, "%f\n", s[k]);
-      }
-      fprintf(fp, "%f\n", -model->rho[0] );
-      fclose(fp);
-    }
-  }
-  // ( Z. Sun )
-  
   if (ferror(fp) != 0 || fclose(fp) != 0) return -1;
   else return 0;
 }
@@ -2881,7 +2833,7 @@ svm_model *svm_load_model(const char *model_file_name)
 {
   FILE *fp = fopen(model_file_name,"rb");
   if(fp==NULL) return NULL;
-  
+
   // read parameters
 
   svm_model *model = Malloc(svm_model,1);
@@ -2920,7 +2872,7 @@ svm_model *svm_load_model(const char *model_file_name)
       }
     }
     else if(strcmp(cmd,"kernel_type")==0)
-    {   
+    {
       fscanf(fp,"%80s",cmd);
       int i;
       for(i=0;kernel_type_table[i];i++)
@@ -2991,7 +2943,7 @@ svm_model *svm_load_model(const char *model_file_name)
       while(1)
       {
         int c = getc(fp);
-        if(c==EOF || c=='\n') break;  
+        if(c==EOF || c=='\n') break;
       }
       break;
     }
@@ -3136,9 +3088,9 @@ const char *svm_check_parameter(const svm_problem *prob, const svm_parameter *pa
      svm_type != EPSILON_SVR &&
      svm_type != NU_SVR)
     return "unknown svm type";
-  
+
   // kernel_type, degree
-  
+
   int kernel_type = param->kernel_type;
   if(kernel_type != LINEAR &&
      kernel_type != NMI &&
@@ -3193,7 +3145,7 @@ const char *svm_check_parameter(const svm_problem *prob, const svm_parameter *pa
 
 
   // check whether nu-svc is feasible
-  
+
   if(svm_type == NU_SVC)
   {
     int l = prob->l;
@@ -3226,7 +3178,7 @@ const char *svm_check_parameter(const svm_problem *prob, const svm_parameter *pa
         ++nr_class;
       }
     }
-  
+
     for(i=0;i<nr_class;i++)
     {
       int n1 = count[i];
@@ -3302,7 +3254,7 @@ double binary_predict_values(const svm_model *model, const svm_node *x, double* 
     int i;
     int nr_class = model->nr_class;
     int l = model->l;
-    
+
     double *kvalue = Malloc(double,l);
     for(i=0;i<l;i++)
       kvalue[i] = Kernel::k_function(x,model->SV[i],model->param);
@@ -3325,7 +3277,7 @@ double binary_predict_values(const svm_model *model, const svm_node *x, double* 
         int sj = start[j];
         int ci = model->nSV[i];
         int cj = model->nSV[j];
-        
+
         int k;
         double *coef1 = model->sv_coef[j-1];
         double *coef2 = model->sv_coef[i];
@@ -3353,7 +3305,7 @@ double binary_predict_values(const svm_model *model, const svm_node *x, double* 
     free(vote);
 //    return model->label[vote_max_idx];
 //    printf("%d %g ", model->label[0], dec_values[0]);
-    
+
     if( model->label[0] < 0 )
       dec_values[0] *= -1;
 //    printf("%g\n", dec_values[0]);
@@ -3369,7 +3321,7 @@ double binary_predict(const svm_model *model, const svm_node *x)
      model->param.svm_type == EPSILON_SVR ||
      model->param.svm_type == NU_SVR)
     dec_values = Malloc(double, 1);
-  else 
+  else
     dec_values = Malloc(double, nr_class*(nr_class-1)/2);
   double pred_result = binary_predict_values(model, x, dec_values);
   free(dec_values);
@@ -3408,10 +3360,10 @@ double binary_predict_probability(
     for(i=0;i<nr_class;i++)
       free(pairwise_prob[i]);
     free(dec_values);
-    free(pairwise_prob);       
+    free(pairwise_prob);
     return model->label[prob_max_idx];
   }
-  else 
+  else
     return binary_predict(model, x);
 }
 
@@ -3425,7 +3377,7 @@ void X_cross_validation(const svm_problem *prob, const svm_parameter *param, int
   int nr_class;
 
   double *dec_values = new double [l];
-  
+
   // stratified cv may not give leave-one-out rate
   // Each class to l folds -> some folds may have zero elements
   if((param->svm_type == C_SVC ||
@@ -3442,7 +3394,7 @@ void X_cross_validation(const svm_problem *prob, const svm_parameter *param, int
     int *index = Malloc(int,l);
     for(i=0;i<l;i++)
       index[i]=perm[i];
-    for (c=0; c<nr_class; c++) 
+    for (c=0; c<nr_class; c++)
       for(i=0;i<count[c];i++)
       {
         int j = i+rand()%(count[c]-i);
@@ -3471,9 +3423,9 @@ void X_cross_validation(const svm_problem *prob, const svm_parameter *param, int
     fold_start[0]=0;
     for (i=1;i<=nr_fold;i++)
       fold_start[i] = fold_start[i-1]+fold_count[i-1];
-    free(start);  
+    free(start);
     free(label);
-    free(count);  
+    free(count);
     free(index);
     free(fold_count);
   }
@@ -3499,7 +3451,7 @@ void X_cross_validation(const svm_problem *prob, const svm_parameter *param, int
     subprob.l = l-(end-begin);
     subprob.x = Malloc(struct svm_node*,subprob.l);
     subprob.y = Malloc(double,subprob.l);
-      
+
     k=0;
     for(j=0;j<begin;j++)
     {
@@ -3514,13 +3466,13 @@ void X_cross_validation(const svm_problem *prob, const svm_parameter *param, int
       ++k;
     }
     struct svm_model *submodel = svm_train(&subprob,param);
-    if(param->probability && 
+    if(param->probability &&
        (param->svm_type == C_SVC || param->svm_type == NU_SVC))
     {
       double *prob_estimates=Malloc(double,svm_get_nr_class(submodel));
       for(j=begin;j<end;j++)
         target[perm[j]] = svm_predict_probability(submodel,prob->x[perm[j]],prob_estimates);
-      free(prob_estimates);     
+      free(prob_estimates);
     }
     else
     {
@@ -3542,12 +3494,12 @@ void X_cross_validation(const svm_problem *prob, const svm_parameter *param, int
   sprintf(fname, "%s/binary_class_cross_valdation.dat", home);
   printf("written detection to file: %s\n", fname);
   FILE *fp=fopen(fname,"w");
-  
+
   for(int j=0;j<l;j++)
     fprintf(fp, "%g\n", dec_values[j]);
 
   delete [] dec_values;
-  
+
   free(fold_start);
-  free(perm); 
+  free(perm);
 }

--- a/bin/iqrTrainClassifier.py
+++ b/bin/iqrTrainClassifier.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+"""
+Train a supervised classifier based on an IQR session state dump.
+
+Descriptors used in IQR, and thus referenced via their UUIDs in the IQR session
+state dump, must exist external to the IQR web-app (uses a non-memory backend).
+This is needed so that this script might access them for classifier training.
+
+Getting an IQR Session's State Info
+===================================
+After working with the IQR application, when it is believed that the return
+results are being ranked accurately, add ``iqr_session_info`` to the end of
+the current URL. This will return JSON data that should be saved, and used as
+input to this utility. This details the data/descriptor UUIDs that were marked
+as positive and negative that will be used to train the configured classifier.
+
+"""
+import argparse
+import json
+import logging
+import os
+
+from smqtk.algorithms import SupervisedClassifier
+from smqtk.algorithms import get_classifier_impls
+
+from smqtk.representation import DescriptorElementFactory
+
+from smqtk.utils.bin_utils import initialize_logging
+from smqtk.utils.bin_utils import output_config
+from smqtk.utils.plugin import make_config
+from smqtk.utils.plugin import from_plugin_config
+
+
+__author__ = "paul.tunison@kitware.com"
+
+
+def get_cli_parser():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('-c', '--config',
+                        help='Path to the configuration file to use (JSON).')
+    parser.add_argument('-g', '--generate-config',
+                        default=False,
+                        help='Optional file path to output a generated '
+                             'configuration file to. If a configuration file '
+                             'was provided, its contents will be included in '
+                             'the generated output.')
+    parser.add_argument('-o', '--overwrite',
+                        action='store_true', default=False,
+                        help='When generating a configuration file, overwrite '
+                             'an existing file.')
+
+    parser.add_argument('-i', '--iqr-session-info',
+                        help="Path to the JSON file saved from an IQR session.")
+    parser.add_argument('-d', '--debug',
+                        action='store_true', default=False,
+                        help='Output debug messages')
+
+    return parser
+
+
+def get_default_config():
+    return {
+        "descriptor_element_factory":
+            DescriptorElementFactory.get_default_config(),
+        "classifier": make_config(get_classifier_impls),
+    }
+
+
+def train_classifier_iqr(config, iqrs_info):
+    log = logging.getLogger(__name__)
+
+    factory = DescriptorElementFactory\
+        .from_config(config['descriptor_element_factory'])
+    #: :type: smqtk.algorithms.SupervisedClassifier
+    classifier = from_plugin_config(config['classifier'], get_classifier_impls)
+
+    if not isinstance(classifier, SupervisedClassifier):
+        raise RuntimeError("Configured classifier must be of the "
+                           "SupervisedClassifier type in order to train.")
+
+    log.info("Loading pos/neg descriptors")
+    d_type_str = iqrs_info['descriptor_type']
+    log.info("-- descriptor algo type: %s", d_type_str)
+    # Using sets to handle possible descriptor duplication in example and
+    # neighbor lists.
+    #: :type: set[smqtk.representation.DescriptorElement]
+    pos = set(
+        [factory(d_type_str, uuid) for uuid in iqrs_info['positive_uids']] +
+        [factory(d_type_str, uuid) for uuid in iqrs_info['ex_pos']]
+    )
+    #: :type: set[smqtk.representation.DescriptorElement]
+    neg = set(
+        [factory(d_type_str, uuid) for uuid in iqrs_info['negative_uids']] +
+        [factory(d_type_str, uuid) for uuid in iqrs_info['ex_neg']]
+    )
+
+    log.info("Checking that descriptors have values")
+    assert all(d.has_vector() for d in pos), \
+        "Some descriptors in positive set do not have vector values."
+    assert all(d.has_vector() for d in neg), \
+        "Some descriptors in negative set do not have vector values."
+
+    classifier.train({'positive': pos}, negatives=neg)
+
+
+def main():
+    log = logging.getLogger(__name__)
+    parser = get_cli_parser()
+    args = parser.parse_args()
+
+    config_path = args.config
+    generate_config = args.generate_config
+    config_overwrite = args.overwrite
+    iqr_session_info_fp = args.iqr_session_info
+    is_debug = args.debug
+
+    initialize_logging(logging.getLogger(),
+                       is_debug and logging.DEBUG or logging.INFO)
+    log.debug("Showing debug messages.")
+
+    config = get_default_config()
+    if config_path and os.path.isfile(config_path):
+        with open(config_path) as f:
+            log.info("Loading configuration: %s", config_path)
+            config.update(
+                json.load(f)
+            )
+    output_config(generate_config, config, log, config_overwrite, 100)
+
+    if not os.path.isfile(iqr_session_info_fp):
+        log.error("IQR Session info JSON filepath was invalid")
+        exit(101)
+
+    with open(iqr_session_info_fp) as f:
+        iqrs_info = json.load(f)
+
+    train_classifier_iqr(config, iqrs_info)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/release_notes/since-last-release.md
+++ b/docs/release_notes/since-last-release.md
@@ -9,6 +9,8 @@ Classifiers
 
   * Added generic Classifier algorithm interface.
 
+  * Added SupervisedClassifier intermediate interface.
+
 Classification Elements
 
   * Added classification result encapsulation interface.
@@ -51,6 +53,9 @@ Tools / Scripts
     Uses JSON configuration file for algorithm and element backend
     specification.
 
+  * Added tool for training a supervised classifier based on an IQR session
+    state (a web-app endpoint return).
+
 Web / Services
 
   * Added ``NearestNeighborServiceServer``, which provides
@@ -59,6 +64,14 @@ Web / Services
 
 Fixes since v0.2.1
 ------------------
+
+Custom LibSVM
+
+  * Fixed an issue where ``svm_save_model`` would crash when saving a 2-class
+    SVM model.
+
+  * Fixed an issue where ``svm_save_model`` would save an extra, unexpected
+    file when saving a 2-class SVM model.
 
 Descriptor Elements
 
@@ -78,3 +91,12 @@ Docs
 
   * Fixed whitespacing issue with ``docs/algorithms.rst`` that prevented
     display of ToC sections.
+
+  * Updated/Fixed various class/function doc-strings.
+
+Utils
+
+  * Fixed ``smqtk.utils.plugin.get_plugins`` to handle skipping intermediate
+    interfaces between the base class and implementation classes, as well as
+    to skip implementation classes that do not fully implement abstract
+    methods.

--- a/python/smqtk/algorithms/__init__.py
+++ b/python/smqtk/algorithms/__init__.py
@@ -20,7 +20,7 @@ class SmqtkAlgorithm (SmqtkObject, Configurable, plugin.Pluggable):
 
 
 # Import module abstracts and plugin getter functions
-from .classifier import Classifier, get_classifier_impls
+from .classifier import Classifier, SupervisedClassifier, get_classifier_impls
 from .descriptor_generator import DescriptorGenerator, get_descriptor_generator_impls
 from .nn_index import NearestNeighborsIndex, get_nn_index_impls
 from .relevancy_index import RelevancyIndex, get_relevancy_index_impls

--- a/python/smqtk/iqr/iqr_controller.py
+++ b/python/smqtk/iqr/iqr_controller.py
@@ -70,7 +70,7 @@ class IqrController (SmqtkObject):
         """ Initialize a new IQR Session, returning the uuid of that session
 
         :param iqr_session: The IqrSession instance to add
-        :type iqr_session: SMQTK.iqr.iqr_session.IqrSession
+        :type iqr_session: smqtk.iqr.iqr_session.IqrSession
 
         :param session_uuid: Optional manual specification of the UUID to assign
             to the instance. This cannot already exist in the controller.
@@ -105,7 +105,7 @@ class IqrController (SmqtkObject):
         :type session_uuid: str or uuid.UUID
 
         :return: IqrSession instance for the given UUID
-        :rtype: SMQTK.iqr.iqr_session.IqrSession
+        :rtype: smqtk.iqr.iqr_session.IqrSession
 
         """
         with self._map_rlock:

--- a/python/smqtk/web/search_app/modules/iqr/iqr_search.py
+++ b/python/smqtk/web/search_app/modules/iqr/iqr_search.py
@@ -7,6 +7,7 @@ import logging
 import os
 import os.path as osp
 import random
+import uuid
 
 import flask
 import PIL.Image
@@ -139,9 +140,10 @@ class IqrSearch (flask.Blueprint, Configurable):
 
         :param nn_index: NearestNeighborsIndex instance for sessions to pull
             their review data sets from.
-        :type nn_index: smqtk.algorithms.nearest
+        :type nn_index: smqtk.algorithms.NearestNeighborsIndex
 
-        :param rel_index_config: Plugin configuration for the
+        :param rel_index_config: Plugin configuration for the RelevancyIndex to
+            use.
         :type rel_index_config: dict
 
         :param working_directory: Directory in which to place working files.
@@ -252,6 +254,11 @@ class IqrSearch (flask.Blueprint, Configurable):
                 # noinspection PyProtectedMember
                 return flask.jsonify({
                     "uuid": iqrs.uuid,
+
+                    "descriptor_type": self._descriptor_generator.name,
+                    "nn_index_type": self._nn_index.name,
+                    "relevancy_index_type": self._rel_index_config['type'],
+
                     "positive_uids":
                         tuple(d.uuid() for d in iqrs.positive_descriptors),
                     "negative_uids":


### PR DESCRIPTION
Primarily added a script to train a supervised classifier based on positive/negative adjudication output of an IQR session.

Other changes:
- Added ``SupervisedClassifier`` intermediate abstract class for trainable classifiers given class examples.
- Fixed libSVM customization that would cause ``free()`` issues in certain cases, as well as caused an additional file to be written. These both only happened when the SVM being saved was 2-class.
- Updated ``get_plugins`` function to handle skipping intermediate abstract classes.