### PR TITLE
Added directory creation if it didn't exist

### DIFF
--- a/python/smqtk/representation/classification_element/file.py
+++ b/python/smqtk/representation/classification_element/file.py
@@ -118,5 +118,6 @@ class FileClassificationElement (ClassificationElement):
         """
         m = super(FileClassificationElement, self)\
             .set_classification(m, **kwds)
+        file_utils.safe_create_dir(osp.dirname(self.filepath))
         with open(self.filepath, 'w') as f:
             cPickle.dump(m, f)


### PR DESCRIPTION
Otherwise exceptions are thrown when trying to set the classification value when base save directories don't exist.