### PR TITLE
Fix: caffe memory descriptor interaction

### DIFF
--- a/bin/iqrTrainClassifier.py
+++ b/bin/iqrTrainClassifier.py
@@ -104,6 +104,8 @@ def train_classifier_iqr(config, iqr_state_fp):
         d.set_vector(numpy.array(v))
         neg.append(d)
         i += 1
+    log.info('    positive -> %d', len(pos))
+    log.info('    negative -> %d', len(neg))
 
     classifier.train({'positive': pos}, negatives=neg)
 

--- a/bin/iqr_app_model_generation.py
+++ b/bin/iqr_app_model_generation.py
@@ -107,7 +107,6 @@ def main():
     # of DescriptorElement to use for storing generated descriptor vectors below.
     descriptor_elem_factory_config = search_app_iqr_config['descriptor_factory']
 
-
     #
     # Initialize data/algorithms
     #

--- a/bin/iqr_app_model_generation.py
+++ b/bin/iqr_app_model_generation.py
@@ -24,15 +24,26 @@ from smqtk.utils import bin_utils, jsmin, plugin
 
 __author__ = 'paul.tunison@kitware.com'
 
+
 def cli_parser():
     description = "Train or generate models for the SMQTK IQR Application"
 
     parser = argparse.ArgumentParser(description=description)
 
-    parser.add_argument("-c","--config",required=True,help="IQR application configuration file.")
-    parser.add_argument("-t","--tab",type=int,default=0,help="The configuration tab to generate the model for.")
+    parser.add_argument("-c", "--config",
+                        required=True,
+                        help="IQR application configuration file.")
+    parser.add_argument("-t", "--tab",
+                        type=int, default=0,
+                        help="The configuration tab to generate the model for.")
+    parser.add_argument('-v', '--verbose',
+                        action='store_true', default=False,
+                        help='Show debug logging.')
 
-    parser.add_argument("input_files",metavar='GLOB',nargs="*")
+    parser.add_argument("input_files",
+                        metavar='GLOB', nargs="*",
+                        help="Shell glob to files to add to the configured "
+                             "data set.")
 
     return parser
 
@@ -45,7 +56,10 @@ def main():
     # Setup logging
     #
     if not logging.getLogger().handlers:
-        bin_utils.initialize_logging(logging.getLogger(), logging.DEBUG)
+        if args.verbose:
+            bin_utils.initialize_logging(logging.getLogger(), logging.DEBUG)
+        else:
+            bin_utils.initialize_logging(logging.getLogger(), logging.INFO)
     log = logging.getLogger("smqtk.scripts.iqr_app_model_generation")
 
     search_app_config = json.loads(jsmin.jsmin(open(args.config).read()))
@@ -141,7 +155,6 @@ def main():
             log.debug("Expanding glob: %s" % fp)
             for g in glob.iglob(fp):
                 data_set.add_data(DataFileElement(g))
-
 
     # Generate a mode if the generator defines a known generation method.
     if hasattr(descriptor_generator, "generate_model"):

--- a/docs/release_notes/since-last-release.md
+++ b/docs/release_notes/since-last-release.md
@@ -17,7 +17,19 @@ Web / Services
 Fixes since v0.2.2
 ------------------
 
+DescriptorElement
+
+  * Fixed mutibility of stored descriptors in DescriptorMemoryElement
+    implementation.
+
 Tools / Scripts
 
   * Added ``Classifier`` interface plugin summarization to
     ``summarizePlugins.py``.
+
+Web / Services
+
+  * Fixed issue with IQR alerts not showing whitespace correctly.
+
+  * Fixed issue with IQR reset not resetting everything, which caused the
+    application to become unusable.

--- a/python/smqtk/iqr/iqr_session.py
+++ b/python/smqtk/iqr/iqr_session.py
@@ -135,7 +135,7 @@ class IqrSession (SmqtkObject):
         #   nn_index instance.
         # Added external data/descriptors not added to this index.
         self.working_index = DescriptorMemoryIndex()
-        
+
         # Initialize book-keeping set so we know what positive descriptors
         # UUIDs we've used to query the neighbor index with already.
         #: :type: set[collections.Hashable]
@@ -383,6 +383,7 @@ class IqrSession (SmqtkObject):
         """
         with self.lock:
             self.working_index.clear()
+            self._wi_init_seeds.clear()
             self.positive_descriptors.clear()
             self.negative_descriptors.clear()
             self.ex_pos_descriptors.clear()

--- a/python/smqtk/representation/descriptor_element/__init__.py
+++ b/python/smqtk/representation/descriptor_element/__init__.py
@@ -21,6 +21,8 @@ class DescriptorElement (SmqtkRepresentation, plugin.Pluggable):
     descriptor generator should not be considered the same (though, this may be
     up for discussion).
 
+    Stored vectors should be effectively immutable.
+
     """
 
     def __init__(self, type_str, uuid):

--- a/python/smqtk/representation/descriptor_element/local_elements.py
+++ b/python/smqtk/representation/descriptor_element/local_elements.py
@@ -179,8 +179,9 @@ class DescriptorFileElement (DescriptorElement):
 
     def vector(self):
         """
-        :return: The descriptor vector as a numpy array.
-        :rtype: numpy.core.multiarray.ndarray
+        :return: Get the stored descriptor vector as a numpy array. This returns
+            None of there is no vector stored in this container.
+        :rtype: numpy.core.multiarray.ndarray or None
         """
         # TODO: Load as memmap?
         #       i.e. modifications by user to vector will be reflected on disk.

--- a/python/smqtk/representation/descriptor_element/local_elements.py
+++ b/python/smqtk/representation/descriptor_element/local_elements.py
@@ -12,7 +12,8 @@ __author__ = "paul.tunison@kitware.com"
 
 class DescriptorMemoryElement (DescriptorElement):
     """
-    In-memory representation of descriptor elements.
+    In-memory representation of descriptor elements. Stored vectors are
+    effectively immutable.
     """
 
     # In-memory cache of descriptor vectors
@@ -57,12 +58,21 @@ class DescriptorMemoryElement (DescriptorElement):
 
     def vector(self):
         """
+        Implementation Note
+        -------------------
+        A copy of the internally stored vector is returned in order to mimic
+        immutability.
+
         :return: Get the stored descriptor vector as a numpy array. This returns
             None of there is no vector stored in this container.
         :rtype: numpy.core.multiarray.ndarray or None
+
         """
+        i = self._get_cache_index()
         with self.MEMORY_CACHE_LOCK:
-            return self.MEMORY_CACHE.get(self._get_cache_index(), None)
+            if i in self.MEMORY_CACHE:
+                return numpy.copy(self.MEMORY_CACHE[i])
+            return None
 
     def set_vector(self, new_vec):
         """
@@ -74,6 +84,11 @@ class DescriptorMemoryElement (DescriptorElement):
         ``new_vec`` may be None, which clears this descriptor's vector from the
         cache.
 
+        Implementation Note
+        -------------------
+        This implementation copies input arrays before storage to mimic
+        immutability.
+
         :param new_vec: New vector to contain.
         :type new_vec: numpy.core.multiarray.ndarray | None
 
@@ -83,7 +98,7 @@ class DescriptorMemoryElement (DescriptorElement):
             if new_vec is None and idx in self.MEMORY_CACHE:
                 del self.MEMORY_CACHE[self._get_cache_index()]
             else:
-                self.MEMORY_CACHE[idx] = new_vec
+                self.MEMORY_CACHE[idx] = numpy.copy(new_vec)
 
 
 class DescriptorFileElement (DescriptorElement):

--- a/python/smqtk/tests/algorithms/classifier/test_libsvm.py
+++ b/python/smqtk/tests/algorithms/classifier/test_libsvm.py
@@ -19,6 +19,10 @@ if LibSvmClassifier.is_usable():
 
     class TestLibSvmClassifier (unittest.TestCase):
 
+        def tearDown(self):
+            # Clear MemoryElement content
+            DescriptorMemoryElement.MEMORY_CACHE = {}
+
         def test_simple_classification(self):
             """
             Test libSVM classification functionality using random constructed

--- a/python/smqtk/tests/algorithms/nn_index/test_NNI_FLANN.py
+++ b/python/smqtk/tests/algorithms/nn_index/test_NNI_FLANN.py
@@ -19,6 +19,9 @@ if FlannNearestNeighborsIndex.is_usable():
 
         RAND_SEED = 42
 
+        def tearDown(self):
+            DescriptorMemoryElement.MEMORY_CACHE = {}
+
         def _make_inst(self, dist_method):
             """
             Make an instance of FlannNearestNeighborsIndex

--- a/python/smqtk/tests/algorithms/nn_index/test_NNI_abstract.py
+++ b/python/smqtk/tests/algorithms/nn_index/test_NNI_abstract.py
@@ -32,8 +32,7 @@ class DummySI (NearestNeighborsIndex):
 
 class TestSimilarityIndexAbstract (unittest.TestCase):
 
-    @classmethod
-    def setUp(cls):
+    def setUp(self):
         # Reset descriptor memory global cache before each test
         DescriptorMemoryElement.MEMORY_CACHE = {}
 

--- a/python/smqtk/tests/algorithms/nn_index/test_NNI_itq.py
+++ b/python/smqtk/tests/algorithms/nn_index/test_NNI_itq.py
@@ -47,6 +47,7 @@ class TestIqrSimilarityIndex (unittest.TestCase):
 
     def tearDown(self):
         self._clean_cache_files()
+        DescriptorMemoryElement.MEMORY_CACHE = {}
 
     def test_configuration(self):
         c = ITQNearestNeighborsIndex.get_default_config()

--- a/python/smqtk/tests/algorithms/relevancy_index/test_iqr_svm_hik.py
+++ b/python/smqtk/tests/algorithms/relevancy_index/test_iqr_svm_hik.py
@@ -39,6 +39,10 @@ class TestIqrSvmHik (unittest.TestCase):
         cls.q_neg = DescriptorMemoryElement('query', 1)
         cls.q_neg.set_vector(np.array([0,   0,   0, .5, .5], float))
 
+    @classmethod
+    def tearDownClass(cls):
+        DescriptorMemoryElement.MEMORY_CACHE = {}
+
     def test_configuration(self):
         c = LibSvmHikRelevancyIndex.get_default_config()
         ntools.assert_in('descr_cache_filepath', c)

--- a/python/smqtk/tests/representation/DescriptorElement/test_DescriptorFileElement.py
+++ b/python/smqtk/tests/representation/DescriptorElement/test_DescriptorFileElement.py
@@ -1,5 +1,8 @@
+import mock
 import nose.tools as ntools
 import unittest
+
+import numpy
 
 from smqtk.representation.descriptor_element.local_elements import DescriptorFileElement
 
@@ -9,7 +12,7 @@ __author__ = "paul.tunison@kitware.com"
 
 class TestDescriptorFileElement (unittest.TestCase):
 
-    def test_configuration(self):
+    def test_configuration1(self):
         default_config = DescriptorFileElement.get_default_config()
         ntools.assert_equal(default_config,
                             {
@@ -30,3 +33,51 @@ class TestDescriptorFileElement (unittest.TestCase):
         inst2 = DescriptorFileElement.from_config(inst1.get_config(),
                                                   'test', 'abcd')
         ntools.assert_equal(inst1, inst2)
+
+    def test_vec_filepath_generation(self):
+        d = DescriptorFileElement('test', 'abcd', '/base', 4)
+        ntools.assert_equal(d._vec_filepath,
+                            '/base/a/b/c/d/test.abcd.vector.npy')
+
+        d = DescriptorFileElement('test', 'abcd', '/base', 2)
+        ntools.assert_equal(d._vec_filepath,
+                            '/base/ab/cd/test.abcd.vector.npy')
+
+        d = DescriptorFileElement('test', 'abcd', '/base', 1)
+        ntools.assert_equal(d._vec_filepath,
+                            '/base/abcd/test.abcd.vector.npy')
+
+        d = DescriptorFileElement('test', 'abcd', '/base', 0)
+        ntools.assert_equal(d._vec_filepath,
+                            '/base/test.abcd.vector.npy')
+
+        d = DescriptorFileElement('test', 'abcd', '/base')
+        ntools.assert_equal(d._vec_filepath,
+                            '/base/test.abcd.vector.npy')
+
+    @mock.patch('smqtk.representation.descriptor_element.local_elements'
+                '.numpy.save')
+    @mock.patch('smqtk.representation.descriptor_element.local_elements'
+                '.file_utils.safe_create_dir')
+    def test_vector_set(self, mock_scd, mock_save):
+        d = DescriptorFileElement('test', 1234, '/base', 4)
+        ntools.assert_equal(d._vec_filepath,
+                            '/base/1/2/3/4/test.1234.vector.npy')
+
+        v = numpy.zeros(16)
+        d.set_vector(v)
+        mock_scd.assert_called_with('/base/1/2/3/4')
+        mock_save.assert_called_with('/base/1/2/3/4/test.1234.vector.npy', v)
+
+    @mock.patch('smqtk.representation.descriptor_element.local_elements'
+                '.numpy.load')
+    def test_vector_get(self, mock_load):
+        d = DescriptorFileElement('test', 1234, '/base', 4)
+        ntools.assert_false(d.has_vector())
+        ntools.assert_is(d.vector(), None)
+
+        d.has_vector = mock.Mock(return_value=True)
+        ntools.assert_true(d.has_vector())
+        v = numpy.zeros(16)
+        mock_load.return_value = v
+        numpy.testing.assert_equal(d.vector(), v)

--- a/python/smqtk/tests/representation/DescriptorElement/test_DescriptorMemoryElement.py
+++ b/python/smqtk/tests/representation/DescriptorElement/test_DescriptorMemoryElement.py
@@ -12,6 +12,16 @@ __author__ = "paul.tunison@kitware.com"
 
 class TestDescriptorMemoryElement (unittest.TestCase):
 
+    def setUp(self):
+        # There should be nothing in the cache
+        assert not DescriptorMemoryElement.MEMORY_CACHE, \
+            "There were things in the memory element cache! %s" \
+            % DescriptorMemoryElement.MEMORY_CACHE
+
+    def tearDown(self):
+        # Reset MemoryElement cache
+        DescriptorMemoryElement.MEMORY_CACHE = {}
+
     def test_configuration(self):
         default_config = DescriptorMemoryElement.get_default_config()
         ntools.assert_equal(default_config, {})

--- a/python/smqtk/tests/representation/DescriptorElement/test_DescriptorMemoryElement.py
+++ b/python/smqtk/tests/representation/DescriptorElement/test_DescriptorMemoryElement.py
@@ -70,3 +70,80 @@ class TestDescriptorMemoryElement (unittest.TestCase):
         # Cache should now have those entries back in it
         ntools.assert_in(('test', 0), DescriptorMemoryElement.MEMORY_CACHE)
         ntools.assert_in(('test', 1), DescriptorMemoryElement.MEMORY_CACHE)
+
+    def test_input_immutability(self):
+        # make sure that data stored is not susceptible to shifts in the
+        # originating data matrix they were pulled from.
+
+        #
+        # Testing this with a single vector
+        #
+        v = numpy.random.rand(16)
+        t = tuple(v.copy())
+        d = DescriptorMemoryElement('test', 0)
+        d.set_vector(v)
+        v[:] = 0
+        ntools.assert_true((v == 0).all())
+        ntools.assert_false(sum(t) == 0.)
+        numpy.testing.assert_equal(d.vector(), t)
+
+        #
+        # Testing with matrix
+        #
+        m = numpy.random.rand(20, 16)
+
+        v1 = m[3]
+        v2 = m[15]
+        v3 = m[19]
+
+        # Save truth values of arrays as immutable tuples (copies)
+        t1 = tuple(v1.copy())
+        t2 = tuple(v2.copy())
+        t3 = tuple(v3.copy())
+
+        d1 = DescriptorMemoryElement('test', 1)
+        d1.set_vector(v1)
+        d2 = DescriptorMemoryElement('test', 2)
+        d2.set_vector(v2)
+        d3 = DescriptorMemoryElement('test', 3)
+        d3.set_vector(v3)
+
+        numpy.testing.assert_equal(v1, d1.vector())
+        numpy.testing.assert_equal(v2, d2.vector())
+        numpy.testing.assert_equal(v3, d3.vector())
+
+        # Changing the source should not change stored vectors
+        m[:, :] = 0.
+        ntools.assert_true((v1 == 0).all())
+        ntools.assert_true((v2 == 0).all())
+        ntools.assert_true((v3 == 0).all())
+        ntools.assert_false(sum(t1) == 0.)
+        ntools.assert_false(sum(t2) == 0.)
+        ntools.assert_false(sum(t3) == 0.)
+        numpy.testing.assert_equal(d1.vector(), t1)
+        numpy.testing.assert_equal(d2.vector(), t2)
+        numpy.testing.assert_equal(d3.vector(), t3)
+
+    def test_output_immutability(self):
+        # make sure that data stored is not susceptible to modifications after
+        # extraction
+        v = numpy.ones(16)
+        d = DescriptorMemoryElement('test', 0)
+        ntools.assert_false(d.has_vector())
+        d.set_vector(v)
+        r = d.vector()
+        r[:] = 0
+        ntools.assert_equal(r.sum(), 0)
+        ntools.assert_equal(d.vector().sum(), 16)
+
+    def test_none_set(self):
+        d = DescriptorMemoryElement('test', 0)
+        ntools.assert_false(d.has_vector())
+
+        d.set_vector(numpy.ones(16))
+        ntools.assert_true(d.has_vector())
+        numpy.testing.assert_equal(d.vector(), numpy.ones(16))
+
+        d.set_vector(None)
+        ntools.assert_false(d.has_vector())
+        ntools.assert_is(d.vector(), None)

--- a/python/smqtk/tests/representation/code_index/test_MemoryCodeIndex.py
+++ b/python/smqtk/tests/representation/code_index/test_MemoryCodeIndex.py
@@ -25,6 +25,9 @@ def random_descriptor():
 
 class TestMemoryCodeIndex (unittest.TestCase):
 
+    def tearDown(self):
+        DescriptorMemoryElement.MEMORY_CACHE = {}
+
     def test_is_usable(self):
         ntools.assert_equal(MemoryCodeIndex.is_usable(), True)
 

--- a/python/smqtk/tests/representation/code_index/test_abstractCodeIndex.py
+++ b/python/smqtk/tests/representation/code_index/test_abstractCodeIndex.py
@@ -39,6 +39,9 @@ class DummyCodeIndex (CodeIndex):
 
 class TestCodeIndexAbstract (unittest.TestCase):
 
+    def tearDown(self):
+        DescriptorMemoryElement.MEMORY_CACHE = {}
+
     @mock.patch.object(DummyCodeIndex, 'count')
     def test_len(self, mock_count):
         mock_count.return_value = 100

--- a/python/smqtk/tests/representation/test_DescriptorElementFactory.py
+++ b/python/smqtk/tests/representation/test_DescriptorElementFactory.py
@@ -116,3 +116,4 @@ class TestDescriptorElemFactory (unittest.TestCase):
         d = factory.new_descriptor('test', 'foo')
         ntools.assert_equal(d.type(), 'test')
         ntools.assert_equal(d.uuid(), 'foo')
+        DescriptorMemoryElement.MEMORY_CACHE = {}

--- a/python/smqtk/utils/distance_functions.py
+++ b/python/smqtk/utils/distance_functions.py
@@ -132,12 +132,12 @@ def hamming_distance(i, j):
     places where the bits differ.
 
     :param i: First integer.
-    :type i: int
+    :type i: int | long
     :param j: Second integer.
-    :type j: int
+    :type j: int | long
 
     :return: Integer hamming distance between the two values.
-    :rtype: int
+    :rtype: int | long
 
     """
     # TODO: Find something better than this.

--- a/python/smqtk/web/search_app/static/js/smqtk.alerts.js
+++ b/python/smqtk/web/search_app/static/js/smqtk.alerts.js
@@ -10,7 +10,8 @@ function alert_error(message) {
              style="padding: 0 .7em;"> \
             <span class="ui-icon ui-icon-alert" \
                   style="float: left; margin-right: .3em;"></span> \
-            <strong>Alert:</strong> ' + message + '\
+            <strong>Alert:</strong> \
+                <span style="white-space: pre-wrap">' + message + '</span>\
             <a class="close" data-dismiss="alert">x</a>\
         </div>'
     );
@@ -34,7 +35,8 @@ function alert_info(message) {
              style="padding: 0 .7em;"> \
                 <span class="ui-icon ui-icon-info" \
                       style="float: left; margin-right: .3em;"></span>\
-                <strong>Info:</strong> ' + message + '\
+                <strong>Info:</strong> \
+                <span style="white-space: pre-wrap">' + message + '</span>\
                 <a class="close" data-dismiss="alert">x</a>\
         </div>'
     );
@@ -57,7 +59,8 @@ function alert_success(message) {
              style="padding: 0 .7em; border: 1px solid #3c763d"> \
                 <span class="ui-icon ui-icon-check" \
                       style="float: left; margin-right: .3em;"></span>\
-                <strong>Success:</strong> ' + message + '\
+                <strong>Success:</strong> \
+                <span style="white-space: pre-wrap">' + message + '</span>\
                 <a class="close" data-dismiss="alert">x</a>\
         </div>'
     );


### PR DESCRIPTION
This PR primarily motivated by DescriptorMemoryElement vector storage being mutable after vector (numpy array views) were stored. Discovered when descriptor output from CaffeDescriptorGenerator.compute_descriptor_async was outputting duplicate descriptors for distinctly different input data elements. This occurred because descriptors were being pulled from a layer matrix in caffe's network. Vectors being stored in memory descriptor elements were actually array views. Thus, when caffe overwrote the result layer during the next feed-forward, the views updated, too, causing the array views already stored to return something different and incorrect.

This branch also bundles in it the following additional fixes found in the process of this hunt:
* bug fix in IQR session where it wasn't resetting everything, which would leave it in a non-functioning state.
* added verbosity control to ``iqr_app_model_generation.py`` tool
* Fixed JS alerts to properly show white-space in input message strings.