### PR TITLE
add log2 for older win compilers (<2013)

### DIFF
--- a/TPL/libsvm-3.1-custom/svm.cpp
+++ b/TPL/libsvm-3.1-custom/svm.cpp
@@ -22,6 +22,14 @@ template <class S, class T> static inline void clone(T*& dst, S* src, int n)
   dst = new T[n];
   memcpy((void *)dst,(void *)src,sizeof(T)*n);
 }
+#if defined(_MSC_VER) && _MSC_VER < 1800
+// Calculates log2 of number.
+static inline float log2( float n )
+{
+  // log(n)/log(2) is log2.
+  return log( n ) / log( 2.0f );
+}
+#endif
 static inline double powi(double base, int times)
 {
   double tmp = base, ret = 1.0;

--- a/docs/release_notes/since-last-release.md
+++ b/docs/release_notes/since-last-release.md
@@ -5,6 +5,11 @@ Changes Since Last Release
 Updates / New Features since v0.2.2
 -----------------------------------
 
+Custom LibSVM
+
+  * Fix compiler error on Windows with Visual Studio < 2013.  Log2 doesn't exist 
+    until that VS version.  Added stand-in.
+
 Tools / Scripts
 
   * Added optional global default config generation to ``summarizePlugins.py``


### PR DESCRIPTION
log2 doesn't exist until VS 2013.  Add it here.