### PR TITLE
Touched up architecture overview doc for typos and linkages

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -14,22 +14,22 @@ SMQTK is mainly comprised of 4 high level components, with additional sub-module
 Plugin Architecture
 -------------------
 
-Each of these main components are housed within distinct sub-modules under ``smqtk`` and adhere to a plugin pattern for the dynamic discovery of implementations.
+Each of these main components are housed within distinct sub-modules under :mod:`smqtk` and adhere to a plugin pattern for the dynamic discovery of implementations.
 
 In SMQTK, data structures and algorithms are first defined by an abstract interface class that lays out what that services the data structure, or methods that the algorithm, should provide.
 This allows users to treat instances of structures and algorithms in a generic way, based on their defined high level functionality, without needing to knowing what specific implementation is running underneath.
 It lies, of course, to the implementations of these interfaces to provide the concrete functionality.
 
 When creating a new data structure or algorithm interface, the pattern is that each interface is defined inside its own sub-module in the ``__init__.py`` file.
-This file also defines a function ``get_..._impls()`` (replacing the ``...`` with the name of the interface) that returns a mapping of implementation class names to the implementation class type, by calling the general helper method [``smqtk.utils.plugin.get_plugins``](/python/smqtk/utils/plugin.py#L69).
-This helper method looks for modules defined parallel to the ``__init__.py`` file as well as classes defined in modules listed in an environment variable (defined by the specific call to [``get_plugins``](/python/smqtk/utils/plugin.py#L69)).
-The function then extracts classes that extend from the specified interface class as specified by a specified helper variable or by searching attributes exposed by the module.
-See the doc-string of [``smqtk.utils.plugin.get_plugins``](/python/smqtk/utils/plugin.py#L69) for more information on how plugin modules are discovered.
+This file also defines a function ``get_..._impls()`` (replacing the ``...`` with the name of the interface) that returns a mapping of implementation class names to the implementation class type, by calling the general helper method :func:`smqtk.utils.plugin.get_plugins`.
+This helper method looks for modules defined parallel to the ``__init__.py`` file as well as classes defined in modules listed in an environment variable (defined by the specific call to :func:`.get_plugins`).
+The function then extracts classes that extend from the specified interface class as denoted by a helper variable in the discovered module or by searching attributes exposed by the module.
+See the doc-string of :func:`smqtk.utils.plugin.get_plugins` for more information on how plugin modules are discovered.
 
 Adding a new Interface and Internal Implementation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For example, lets say we're creating a new data representation interface called ``FooBar``.
-We would create a directory and ``__init__.py`` file (python module) to house the interface as follows::
+For example, lets say we're creating a new data representation interface called :class:`FooBar`.
+We would create a directory and :file:`__init__.py` file (python module) to house the interface as follows::
 
     python/
     └── smqtk/
@@ -37,11 +37,10 @@ We would create a directory and ``__init__.py`` file (python module) to house th
             └── foo_bar/          # new
                 └── __init__.py   # new
 
+Since we are making a new data representation interface, our new interface should descend from the :class:`smqtk.representation.SmqtkRepresentation` interface (algorithm interfaces would descend from :class:`smqtk.algorithms.SmqtkAlgorithm`).
+The :class:`.SmqtkRepresentation` base-class descends from the :class:`.Configurable` interface (interface class sets ``__metaclass__ = abc.ABCMeta``, thus it is not set in the example below).
 
-Since we are making a new data representation interface, our new interface should descend from the ``SmqtkRepresentation`` interface defined in the ``smqtk.representation`` module (algorithm interfaces would descend from ``smqtk.algorithms.SmqtkAlgorithm``).
-The ``SmqtkRepresentation`` base-class descends from the [``Configurable``](/python/smqtk/utils/configurable_interface.py#L8) interface (interface class sets ``__metaclass__ = abc.ABCMeta``, thus it is not set in the example below).
-
-The ``__init__.py`` file for our new sub-module might look something like the following, defining a new abstract class:
+The :file:`__init__.py` file for our new sub-module might look something like the following, defining a new abstract class:
 
 .. code-block:: python
 
@@ -82,7 +81,7 @@ When adding a an implementation class, if it is sufficient to be contained in a 
                 ├── __init__.py
                 └── some_impl.py  # new
 
-Where ``some_impl.py`` might look like:
+Where :file:`some_impl.py` might look like:
 
 .. code-block:: python
 
@@ -96,7 +95,7 @@ Where ``some_impl.py`` might look like:
 
 
 Implementation classes can also live inside of a nested sub-module.
-This is useful when an implementation class requires specific or extensive support utilities (for example, see the ``DescriptorGenerator`` implementation [``ColorDescriptor``](/python/smqtk/algorithms/descriptor_generator/colordescriptor)).::
+This is useful when an implementation class requires specific or extensive support utilities (for example, see the :class:`.DescriptorGenerator` implementation :class:`.ColorDescriptor`).::
 
     python/
     └── smqtk/
@@ -107,14 +106,14 @@ This is useful when an implementation class requires specific or extensive suppo
                 └── other_impl/      # new
                     └── __init__.py  # new
 
-Where the ``__init__.py`` file should at least expose concrete implementation classes that should be exported as attributes for the plugin getter to discover.
+Where the :file:`__init__.py` file should at least expose concrete implementation classes that should be exported as attributes for the plugin getter to discover.
 
 
-Both ``Pluggable`` and ``Confiugrable``
-"""""""""""""""""""""""""""""""""""""""
-It is important to note that our new interface, as defined above, descends from both the ``Configurable`` interface (transitive through the ``SmqtkRepresentation`` base-class) and the ``Pluggable`` interface.
+Both :class:`.Pluggable` and :class:`.Configurable`
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+It is important to note that our new interface, as defined above, descends from both the :class:`.Configurable` interface (transitive through the :class:`.SmqtkRepresentation` base-class) and the :class:`.Pluggable` interface.
 
-The ``Configurable`` interface allows classes to be instantiated via a dictionary with JSON-compliant data types.
+The :class:`.Configurable` interface allows classes to be instantiated via a dictionary with JSON-compliant data types.
 In conjunction with the plugin getter function (``get_foo_bar_impls`` in our example above), we are able to select and construct specific implementations of an interface via a configuration or during runtime (e.g. via a transcoded JSON object).
 With this flexibility, an application can set up a pipeline using the high-level interfaces as reference, allowing specific implementations to be swapped in an out via configuration.
 
@@ -122,5 +121,17 @@ With this flexibility, an application can set up a pipeline using the high-level
 Reload Use Warning
 """"""""""""""""""
 
-While the [``smqtk.utils.plugin.get_plugins``](/python/smqtk/utils/plugin.py) function allows for reloading discovered modules for potentially new content, this is not recommended under normal conditions.
-When reloading a plugin module after ``pickle`` serializing an instance of an implementation, deserialization causes an error because the original class type that was pickled is no longer valid as the reloaded model overwrote the previous plugin class type.
+While the :func:`smqtk.utils.plugin.get_plugins` function allows for reloading discovered modules for potentially new content, this is not recommended under normal conditions.
+When reloading a plugin module after :mod:`pickle` serializing an instance of an implementation, deserialization causes an error because the original class type that was pickled is no longer valid as the reloaded module overwrote the previous plugin class type.
+
+
+Function and Interface Reference
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: smqtk.utils.plugin.get_plugins
+
+.. autoclass:: smqtk.utils.plugin.Pluggable
+   :members:
+
+.. autoclass:: smqtk.utils.configurable_interface.Configurable
+   :members:

--- a/python/smqtk/algorithms/nn_index/lsh/functors/__init__.py
+++ b/python/smqtk/algorithms/nn_index/lsh/functors/__init__.py
@@ -50,10 +50,10 @@ def get_lsh_functor_impls(reload_modules=False):
     actual class type objects.
 
     We search for implementation classes in:
-        - modules next to this file this function is defined in (ones that begin
-          with an alphanumeric character),
+        - modules next to this file this function is defined in (ones that
+          begin with an alphanumeric character),
         - python modules listed in the environment variable
-          ``LSH_FUNCTOR_PATH``
+          :envvar:`LSH_FUNCTOR_PATH`
             - This variable should contain a sequence of python module
               specifications, separated by the platform specific PATH separator
               character (``;`` for Windows, ``:`` for unix)
@@ -69,7 +69,7 @@ def get_lsh_functor_impls(reload_modules=False):
     :param reload_modules: Explicitly reload discovered modules from source.
     :type reload_modules: bool
 
-    :return: Map of discovered class object of type ``LshFunctor``
+    :return: Map of discovered class object of type :class:`.LshFunctor`
         whose keys are the string names of the classes.
     :rtype: dict[str, type]
 

--- a/python/smqtk/utils/__init__.py
+++ b/python/smqtk/utils/__init__.py
@@ -1,7 +1,7 @@
 """
 LICENCE
 -------
-Copyright 2013 by Kitware, Inc. All Rights Reserved. Please refer to
+Copyright 2013-2016 by Kitware, Inc. All Rights Reserved. Please refer to
 KITWARE_LICENSE.TXT for licensing information, or contact General Counsel,
 Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
 

--- a/python/smqtk/utils/plugin.py
+++ b/python/smqtk/utils/plugin.py
@@ -3,17 +3,18 @@ Helper interface and functions for higher level plugin module getter methods.
 
 Plugin configuration dictionaries take the following general format:
 
+.. code-block:: json
+
     {
         "type": "name",
         "impl_name": {
             "param1": "val1",
-            "param2": "val2",
-            ...
+            "param2": "val2"
         },
         "other_impl": {
-            ...
-        },
-        ... (etc.)
+            "p1": 4.5,
+            "p2": null
+        }
     }
 
 """


### PR DESCRIPTION
Its definitely not markdown any more, so I cleaned that up.