### PR TITLE
NNSS compute descriptor endpoint

### DIFF
--- a/bin/memex/run.update.sh
+++ b/bin/memex/run.update.sh
@@ -360,6 +360,12 @@ with open('${remote_file_list}') as pth_f:
     fi
 fi
 
+if [ "$(cat "${local_file_list}" | wc -l)" -eq 0 ]
+then
+    error "No local files downloaded"
+    exit 1
+fi
+
 
 #
 # Compute descriptors

--- a/python/smqtk/web/iqr_service/__init__.py
+++ b/python/smqtk/web/iqr_service/__init__.py
@@ -174,6 +174,12 @@ class IqrService (SmqtkWebApp):
         if sid is None:
             sid = new_uuid()
 
+        if self.controller.has_session_uuid(sid):
+            return make_response_json(
+                "Session with id '%s' already exists" % sid,
+                sid=sid,
+            ), 409  # CONFLICT
+
         iqrs = iqr_session.IqrSession()
         with self.controller:
             with iqrs:
@@ -182,7 +188,7 @@ class IqrService (SmqtkWebApp):
                 self.session_classifier_dirty[sid] = True
 
         return make_response_json("Created new session with ID '%s'" % sid,
-                                  sid=sid), 201
+                                  sid=sid), 201  # CREATED
 
     # PUT
     def reset_session(self):


### PR DESCRIPTION
This is basically a duplication of the functionality provided by the descriptor service, but only uses the single generator configuration. Hooks into updating the configured descriptor index if the service is configured for index updating.