### PR TITLE
Added a default factory for descriptor generators

### DIFF
--- a/python/smqtk/algorithms/descriptor_generator/__init__.py
+++ b/python/smqtk/algorithms/descriptor_generator/__init__.py
@@ -6,12 +6,18 @@ import os
 import traceback
 
 from smqtk.algorithms import SmqtkAlgorithm
+from smqtk.representation import DescriptorElementFactory
+from smqtk.representation.descriptor_element.local_elements import \
+    DescriptorMemoryElement
 from smqtk.utils import SimpleTimer
 import smqtk.utils.parallel
 from smqtk.utils.plugin import get_plugins
 
 
 __author__ = "paul.tunison@kitware.com"
+
+
+DFLT_DESCRIPTOR_FACTORY = DescriptorElementFactory(DescriptorMemoryElement, {})
 
 
 class DescriptorGenerator (SmqtkAlgorithm):
@@ -27,7 +33,8 @@ class DescriptorGenerator (SmqtkAlgorithm):
         :rtype: set[str]
         """
 
-    def compute_descriptor(self, data, descr_factory, overwrite=False):
+    def compute_descriptor(self, data, descr_factory=DFLT_DESCRIPTOR_FACTORY,
+                           overwrite=False):
         """
         Given some kind of data, return a descriptor element containing a
         descriptor vector.
@@ -80,7 +87,8 @@ class DescriptorGenerator (SmqtkAlgorithm):
 
         return descr_elem
 
-    def compute_descriptor_async(self, data_iter, descr_factory,
+    def compute_descriptor_async(self, data_iter,
+                                 descr_factory=DFLT_DESCRIPTOR_FACTORY,
                                  overwrite=False, procs=None, **kwds):
         """
         Asynchronously compute feature data for multiple data items.

--- a/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
@@ -9,7 +9,11 @@ import numpy
 import PIL.Image
 import PIL.ImageFile
 
-from smqtk.algorithms import DescriptorGenerator
+from smqtk.algorithms.descriptor_generator import \
+    DescriptorGenerator, \
+    DFLT_DESCRIPTOR_FACTORY
+
+from smqtk.utils.bin_utils import report_progress
 
 try:
     import caffe
@@ -244,7 +248,8 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
                                   "compute_descriptor[_async] is being "
                                   "overridden")
 
-    def compute_descriptor(self, data, descr_factory, overwrite=False):
+    def compute_descriptor(self, data, descr_factory=DFLT_DESCRIPTOR_FACTORY,
+                           overwrite=False):
         """
         Given some kind of data, return a descriptor element containing a
         descriptor vector.
@@ -279,7 +284,8 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
                                           procs=1)
         return m[data]
 
-    def compute_descriptor_async(self, data_iter, descr_factory,
+    def compute_descriptor_async(self, data_iter,
+                                 descr_factory=DFLT_DESCRIPTOR_FACTORY,
                                  overwrite=False, procs=None, **kwds):
         """
         Asynchronously compute feature data for multiple data items.


### PR DESCRIPTION
Defaulted in the interface as well as in the Caffe generator option.
Defaults can be added to other less used implementations when necessary
at a later time.