### PR TITLE
Fixed bug with element iteration in ``compute_many_descriptors`` function

### DIFF
--- a/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
@@ -330,6 +330,7 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
         descr_elements = {}
         self._log.debug("Checking content types; aggregating data/descriptor "
                         "elements.")
+        prog_rep_state = [0] * 7
         for d in data_iter:
             ct = d.content_type()
             if ct not in self.valid_content_types():
@@ -337,6 +338,7 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
                                  "'%s', (DE: %s" % (ct, d))
             data_elements[d.uuid()] = d
             descr_elements[d.uuid()] = descr_factory.new_descriptor(self.name, d.uuid())
+            report_progress(self._log.debug, prog_rep_state, 1.0)
         self._log.debug("Given %d unique data elements", len(data_elements))
 
         # Reduce procs down to the number of elements to process if its smaller
@@ -376,7 +378,7 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
 
             if batch_groups:
                 for g in xrange(batch_groups):
-                    self._log.debug("Starting batch: %d", g)
+                    self._log.debug("Starting batch: %d of %d", g, batch_groups)
                     batch_uuids = \
                         uuid4proc[g*self.batch_size:(g+1)*self.batch_size]
                     self._process_batch(batch_uuids, data_elements,

--- a/python/smqtk/compute_functions.py
+++ b/python/smqtk/compute_functions.py
@@ -84,13 +84,18 @@ def compute_many_descriptors(file_elements, descr_generator, descr_factory,
     total = 0
     unique = 0
 
+    def iter_capture_elements():
+        for dfe in file_elements:
+            dfe_deque.append(dfe)
+            yield dfe
+
     if batch_size:
         log.debug("Computing in batches of size %d", batch_size)
 
         batch_i = 0
 
-        for dfe in file_elements:
-            # element captured in dfe_deque
+        for dfe in iter_capture_elements():
+            # elements captured in iter_capture_elements
 
             if len(dfe_deque) == batch_size:
                 batch_i += 1
@@ -140,7 +145,7 @@ def compute_many_descriptors(file_elements, descr_generator, descr_factory,
         # Just do everything in one call
         log.debug("Computing descriptors")
         m = descr_generator.compute_descriptor_async(
-            file_elements, descr_factory,
+            iter_capture_elements(), descr_factory,
             overwrite, procs, **kwds
         )
 


### PR DESCRIPTION
Wasn't correctly iterating over elements when ``file_elements`` iterated the second time. Introduced a small internal wrapper function that captures iterated elements into a ``deque``.