### PR TITLE
Various updates and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,16 +65,6 @@ configure_file("${SMQTK_SOURCE_DIR}/setup_env.install.sh.in"
 # System Installation
 #
 
-# Initially set custom install path
-# User can change this later as desired after the first configuration pass has
-#   completed
-if (NOT SMQTK_FIRST_PASS_COMPLETE)
-  set(CMAKE_INSTALL_PREFIX "/opt/kitware/SMQTK"
-    CACHE PATH
-    "Install path prefix, prepended onto install directories."
-    FORCE)
-endif(NOT SMQTK_FIRST_PASS_COMPLETE)
-
 install(DIRECTORY DESTINATION var/data)
 
 if(UNIX)
@@ -141,8 +131,3 @@ set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_SYSTEM_NAME}")
 
 include(CPack)
-
-if (NOT SMQTK_FIRST_PASS_COMPLETE)
-  set(SMQTK_FIRST_PASS_COMPLETE True CACHE BOOL "SMQTK first pass configuration complete" FORCE)
-  mark_as_advanced(SMQTK_FIRST_PASS_COMPLETE)
-endif(NOT SMQTK_FIRST_PASS_COMPLETE)

--- a/docs/release_notes/since-last-release.md
+++ b/docs/release_notes/since-last-release.md
@@ -13,3 +13,7 @@ Classifier
 
 Fixes since v0.4.0
 ------------------
+
+CMake
+
+  * Removed ``SMQTK_FIRST_PASS_COMPLETE`` stuff in root CMakeLists.txt

--- a/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
@@ -264,7 +264,8 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
         :type data: smqtk.representation.DataElement
 
         :param descr_factory: Factory instance to produce the wrapping
-            descriptor element instance.
+            descriptor element instance. In-Memory descriptor factory by
+            default.
         :type descr_factory: smqtk.representation.DescriptorElementFactory
 
         :param overwrite: Whether or not to force re-computation of a descriptor
@@ -296,7 +297,8 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
         :type data_iter: collections.Iterable[smqtk.representation.DataElement]
 
         :param descr_factory: Factory instance to produce the wrapping
-            descriptor element instances.
+            descriptor element instances. In-Memory descriptor factory by
+            default.
         :type descr_factory: smqtk.representation.DescriptorElementFactory
 
         :param overwrite: Whether or not to force re-computation of a descriptor
@@ -378,7 +380,8 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
 
             if batch_groups:
                 for g in xrange(batch_groups):
-                    self._log.debug("Starting batch: %d of %d", g, batch_groups)
+                    self._log.debug("Starting batch: %d of %d",
+                                    g + 1, batch_groups)
                     batch_uuids = \
                         uuid4proc[g*self.batch_size:(g+1)*self.batch_size]
                     self._process_batch(batch_uuids, data_elements,

--- a/python/smqtk/algorithms/nn_index/flann.py
+++ b/python/smqtk/algorithms/nn_index/flann.py
@@ -6,6 +6,7 @@ import os.path as osp
 import numpy
 
 from smqtk.algorithms.nn_index import NearestNeighborsIndex
+from smqtk.representation.descriptor_element import elements_to_matrix
 from smqtk.utils.file_utils import safe_create_dir
 
 try:
@@ -276,8 +277,9 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         pyflann.set_distance_type(self._distance_method)
 
         self._log.debug("Accumulating descriptor vectors into matrix for FLANN")
-        pts_array = [d.vector() for d in self._descr_cache]
-        pts_array = numpy.array(pts_array, dtype=pts_array[0].dtype)
+        pts_array = elements_to_matrix(self._descr_cache, report_interval=1.0)
+
+        self._log.debug('Building FLANN index')
         self._flann = pyflann.FLANN()
         self._flann_build_params = self._flann.build_index(pts_array, **params)
         del pts_array
@@ -328,14 +330,14 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         #
         # FLANN asserts that we query for <= index size, thus the use of min()
         if self._distance_method == 'hik':
-            #: :type: numpy.core.multiarray.ndarray, numpy.core.multiarray.ndarray
+            #: :type: numpy.ndarray, numpy.ndarray
             idxs, dists = self._flann.nn_index(vec, len(self._descr_cache),
                                                **self._flann_build_params)
             # Invert values to stay consistent with other distance value norms
             dists = [1.0 - d for d in dists]
 
         else:
-            #: :type: numpy.core.multiarray.ndarray, numpy.core.multiarray.ndarray
+            #: :type: numpy.ndarray, numpy.ndarray
             idxs, dists = self._flann.nn_index(vec,
                                                min(n, len(self._descr_cache)),
                                                **self._flann_build_params)
@@ -348,7 +350,7 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         if self._distance_method == 'hik':
             idxs = tuple(reversed(idxs))[:n]
             dists = tuple(reversed(dists))[:n]
-        return [self._descr_cache[i] for i in idxs], dists
+        return [self._descr_cache[i] for i in idxs], dists.tolist()
 
 
 NN_INDEX_CLASS = FlannNearestNeighborsIndex

--- a/python/smqtk/algorithms/nn_index/flann.py
+++ b/python/smqtk/algorithms/nn_index/flann.py
@@ -330,12 +330,11 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         #
         # FLANN asserts that we query for <= index size, thus the use of min()
         if self._distance_method == 'hik':
+            # This call is different than the else version in that k is the size
+            # of the full data set, so that we can reverse the distances
             #: :type: numpy.ndarray, numpy.ndarray
             idxs, dists = self._flann.nn_index(vec, len(self._descr_cache),
                                                **self._flann_build_params)
-            # Invert values to stay consistent with other distance value norms
-            dists = [1.0 - d for d in dists]
-
         else:
             #: :type: numpy.ndarray, numpy.ndarray
             idxs, dists = self._flann.nn_index(vec,
@@ -347,10 +346,16 @@ class FlannNearestNeighborsIndex (NearestNeighborsIndex):
         if len(idxs.shape) > 1:
             idxs = idxs[0]
             dists = dists[0]
+
         if self._distance_method == 'hik':
+            # Invert values to stay consistent with other distance value norms
+            dists = [1.0 - d for d in dists]
             idxs = tuple(reversed(idxs))[:n]
             dists = tuple(reversed(dists))[:n]
-        return [self._descr_cache[i] for i in idxs], dists.tolist()
+        else:
+            dists = tuple(dists)
+
+        return [self._descr_cache[i] for i in idxs], dists
 
 
 NN_INDEX_CLASS = FlannNearestNeighborsIndex

--- a/python/smqtk/representation/data_element/file_element.py
+++ b/python/smqtk/representation/data_element/file_element.py
@@ -41,7 +41,8 @@ class DataFileElement (DataElement):
         """
         super(DataFileElement, self).__init__()
 
-        self._filepath = osp.abspath(osp.expanduser(filepath))
+        # Just expand a user-home `~` if present, keep relative if given.
+        self._filepath = osp.expanduser(filepath)
 
         self._content_type = None
         if tika_detector:

--- a/python/smqtk/tests/algorithms/nn_index/test_NNI_FLANN.py
+++ b/python/smqtk/tests/algorithms/nn_index/test_NNI_FLANN.py
@@ -78,6 +78,7 @@ if FlannNearestNeighborsIndex.is_usable():
             r, dists = index.nn(q, i)
             for j, d, dist in zip(range(i), r, dists):
                 ntools.assert_equal(d.uuid(), j)
+                numpy.testing.assert_equal(d.vector(), [j, j*2])
 
         def test_known_descriptors_hik_unit(self):
             dim = 5

--- a/python/smqtk/tests/representation/DataElement/test_DataFileElement.py
+++ b/python/smqtk/tests/representation/DataElement/test_DataFileElement.py
@@ -17,11 +17,10 @@ class TestDataFileElement (unittest.TestCase):
         ntools.assert_equal(d._filepath, fp)
 
     def test_init_relFilepath_normal(self):
-        # relative paths should be stored as absolute within the element
+        # relative paths should be stored as given within the element
         fp = 'foo.txt'
         d = DataFileElement(fp)
-        ntools.assert_equal(d._filepath,
-                            os.path.join(os.getcwd(), fp))
+        ntools.assert_equal(d._filepath, fp)
 
     def test_content_type(self):
         d = DataFileElement('foo.txt')

--- a/python/smqtk/utils/distance_functions.py
+++ b/python/smqtk/utils/distance_functions.py
@@ -151,8 +151,12 @@ def cosine_distance(i, j):
 
 def hamming_distance(i, j):
     """
-    Return the hamming distance between the two given integers, or the number of
-    places where the bits differ.
+    Return the hamming distance between the two given pythonic integers, or the
+    number of places where the bits differ.
+
+    **Note:** *We say "pythonic" integer here because this function has no cap
+    on the number of bits used to represent said integer. This function will
+    execute correctly regardless whether i/j is 32 bits or 512 bits, etc."
 
     :param i: First integer.
     :type i: int | long
@@ -163,7 +167,7 @@ def hamming_distance(i, j):
     :rtype: int | long
 
     """
-    # TODO: Find something better than this.
+    # TODO: Find something better than this?
     return bin(i ^ j).count('1')
 
 
@@ -171,6 +175,9 @@ def popcount(v):
     """
     Pure python popcount algorithm adapted implementation at:
     see: https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
+
+    This is limited to 32-bit integer representation.
+
     """
     # TODO: C implementation of this
     #       since this version, being in python, isn't faster than above bin

--- a/python/smqtk/utils/distance_kernel.py
+++ b/python/smqtk/utils/distance_kernel.py
@@ -77,8 +77,10 @@ def compute_distance_kernel(m, dist_func, row_wise=False, parallel=True):
                 if i < (side - 1):
                     mat[i + 1:, i] = mat[i, i + 1:] = dist_func(m[i, :],
                                                                 m[i + 1:, :])
+            # Using threading for in-place modification
             s = [0] * 7
-            for _ in parallel_map(work_func, xrange(side)):
+            for _ in parallel_map(work_func, xrange(side),
+                                  use_multiprocessing=False):
                 report_progress(log.debug, s, 1.)
         else:
             for i in xrange(side):
@@ -94,8 +96,10 @@ def compute_distance_kernel(m, dist_func, row_wise=False, parallel=True):
                 # cols to the left of diagonal index for this row
                 for j in xrange(i):
                     mat[i, j] = mat[j, i] = dist_func(m[i], m[j])
+            # Using threading for in-place modification
             s = [0] * 7
-            for _ in parallel_map(work_func, xrange(side)):
+            for _ in parallel_map(work_func, xrange(side),
+                                  use_multiprocessing=False):
                 report_progress(log.debug, s, 1.)
         else:
             for i in xrange(side):

--- a/python/smqtk/web/nearestneighbor_service/__init__.py
+++ b/python/smqtk/web/nearestneighbor_service/__init__.py
@@ -167,7 +167,6 @@ class NearestNeighborServiceServer (SmqtkWebApp):
 
                 - local filepath
                 - base64
-                - direct descriptor vector
                 - http/s URL
 
             The following sub-sections detail how different URI's can be used.
@@ -193,7 +192,8 @@ class NearestNeighborServiceServer (SmqtkWebApp):
             This uses the requests module to locally download a data file
             for processing.
 
-            JSON Return format::
+            JSON Return format
+            ------------------
                 {
                     "success": <bool>
 
@@ -235,13 +235,14 @@ class NearestNeighborServiceServer (SmqtkWebApp):
 
             # TODO: Return the optional descriptor vectors for the neighbors
             # noinspection PyTypeChecker
-            return flask.jsonify({
-                "success": descriptor is not None,
+            d = {
+                "success": bool(descriptor is not None),
                 "message": message,
                 "neighbors": [n.uuid() for n in neighbors[page_slice]],
                 "distances": dists[page_slice],
                 "reference_uri": uri
-            })
+            }
+            return flask.jsonify(d)
 
     def get_config(self):
         return self.json_config


### PR DESCRIPTION
- Added more comments/detail in places.
- fixed caffe descriptor batch logging counter
- Added use of elements_to_matrix function in FLANN nn-index instead of
  performing the old serial version.
- fixed FLANN nn function to return a list like the docstring states instead
  of a numpy.ndarray.
- Removed absolute-path transformation from DataFileElement class constructor,
  allowing the recording of a dataset using relative paths, which is more
  transportable.
- declared explicit use of threading in ``compute_distance_kernel`` function