### PR TITLE
iqr service session expiration

### DIFF
--- a/docs/release_notes/v0.6.0.md
+++ b/docs/release_notes/v0.6.0.md
@@ -22,6 +22,11 @@ Descriptor Index
   * DescriptorIndex instances, when iterated over, now yield DescriptorElement
     instances instead of just the UUID keys.
 
+IQR
+
+  * Added optional session expiration feature to ``IqrController`` class to
+    allow for long-term self clean-up.
+
 Nearest Neighbors Index
 
   * Changed ITQ fit method to by default use multiprocessing over threading,
@@ -46,6 +51,10 @@ Descriptor Index
 
   * Fixed PostgreSQL backend bug when iterating over descriptors that caused
     inconsistent/duplicate elements in iterated values.
+
+IQR
+
+  * Fixed how IqrController used and managed session UUID values.
 
 Utilities
 

--- a/docs/release_notes/v0.6.0.md
+++ b/docs/release_notes/v0.6.0.md
@@ -43,6 +43,11 @@ Scripts
 
   * Simplified the ``train_itq.py`` script a little.
 
+Web Apps
+
+  * Added configuration of IqrController session expiration monitoring to IQR
+    RESTful (ish) service.
+
 
 Fixes since v0.5.0
 ------------------

--- a/python/smqtk/iqr/iqr_controller.py
+++ b/python/smqtk/iqr/iqr_controller.py
@@ -1,4 +1,6 @@
-import multiprocessing
+import atexit
+import threading
+import time
 import uuid
 
 from smqtk.utils import SmqtkObject
@@ -18,13 +20,53 @@ class IqrController (SmqtkObject):
 
     """
 
-    def __init__(self):
+    def __init__(self, expire_enabled=False, expire_check=30):
+        """
+        Initialize the controller.
+
+        Session timeout, when enabled, is set on a session-by-session basis,
+        i.e. different session may have different time out values if desired.
+        When expiration is not enabled, session timeout values are ignored.
+
+        :param expire_enabled: Enable/Disable session expiry. If enabled, a
+            thread is started for monitoring and removal.
+        :type expire_enabled:
+
+        :param expire_check: Interval, in seconds, that we check for session
+            expiration.
+        :type expire_check: float
+        """
+
         # Map of uuid to the search state
         #: :type: dict[collections.Hashable, IqrSession]
         self._iqr_sessions = {}
+        # Map of sessions with timeout's enabled and the time out value in
+        # seconds
+        #: :type
+        self._iqr_session_timeout = {}
+        # Map of the UNIX time a session was last accessed
+        self._iqr_session_last_access = {}
 
-        # RLock for iqr_session{_locks} maps.
-        self._map_rlock = multiprocessing.RLock()
+        # RLock for iqr_session[*] maps.
+        self._map_rlock = threading.RLock()
+
+        self._expire_enabled = expire_enabled
+        self._expire_interval = expire_check
+        self._expire_thread_stop_event = threading.Event()
+        # prevents calling _handle_session_expiration when not enabled
+        self._expire_thread_stop_event.set()
+        self._expire_thread = None
+
+        # If enabled, start expiration monitor thread
+        if self._expire_enabled:
+            self._log.debug("Starting session expiration monitor thread")
+            self._expire_thread = threading.Thread(
+                target=self._handle_session_expiration
+            )
+            self._expire_thread.daemon = True
+            self._expire_thread_stop_event.clear()  # revert L:57
+            self._expire_thread.start()
+            atexit.register(self._stop_expiration_monitor)
 
     def __enter__(self):
         self._map_rlock.acquire()
@@ -33,9 +75,41 @@ class IqrController (SmqtkObject):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._map_rlock.release()
 
+    def _handle_session_expiration(self):
+        """
+        Run on a separate thread periodic checks and removals of sessions that
+        have expired.
+        """
+        while not self._expire_thread_stop_event.wait(self._expire_interval):
+            # scan timeout-set sessions, removing those that have timed out
+            now = time.time()
+            with self._map_rlock:
+                self._log.debug("Checking session expiration timeouts")
+                for sid in self._iqr_session_timeout.keys():
+                    to = self._iqr_session_timeout[sid]
+                    la = self._iqr_session_last_access[sid]
+                    t = now - la
+                    if t > to:
+                        self._log.debug("-> Expiring session '%s' "
+                                        "(last-access: %s, timeout: %s, "
+                                        "now: %s)", sid, la, to, now)
+                        self.remove_session(sid)
+
+        self._log.debug("End of expiration handle function")
+
+    def _stop_expiration_monitor(self):
+        if self._expire_thread:
+            self._log.debug("Stopping session expiration monitor thread")
+            self._expire_thread_stop_event.set()
+            self._expire_thread.join()
+            self._log.debug("Stopping session expiration monitor thread -- Done")
+
     def session_uuids(self):
         """
         Return a tuple of all currently registered IqrSessions.
+
+        This does NOT update session last access in regards to session
+        expiration.
 
         :return: a tuple of all currently registered IqrSessions.
         :rtype: tuple of collections.Hashable
@@ -49,7 +123,10 @@ class IqrController (SmqtkObject):
         ID.
 
         Performance using this function is faster compared to getting all UUIDs
-        and performing a linear search.
+        and performing a linear search (because hash tables).
+
+        This does NOT update session last access in regards to session
+        expiration.
 
         :param session_uuid: Possible UUID of a session
         :type session_uuid: collections.Hashable
@@ -62,34 +139,34 @@ class IqrController (SmqtkObject):
         with self._map_rlock:
             return session_uuid in self._iqr_sessions
 
-    def add_session(self, iqr_session, session_uuid=None):
+    def add_session(self, iqr_session, timeout=0):
         """ Initialize a new IQR Session, returning the uuid of that session
+
+        This controller indexes the given session by its UUID.
 
         :param iqr_session: The IqrSession instance to add
         :type iqr_session: smqtk.iqr.iqr_session.IqrSession
 
-        :param session_uuid: Optional manual specification of the UUID to assign
-            to the instance. This cannot already exist in the controller.
-        :type session_uuid: collections.Hashable
+        :param timeout: The optional timeout, in seconds.
+        :type timeout: float
 
         :return: UUID of new IQR Session
         :rtype: collections.Hashable
 
         """
+        timeout = float(timeout)
         with self._map_rlock:
-            if not session_uuid:
-                session_uuid = uuid.uuid1()
-                assert session_uuid not in self._iqr_sessions, \
-                    "Generated a new random UUID that already exists in " \
-                    "session map."
-            else:
-                if session_uuid in self._iqr_sessions:
-                    raise RuntimeError("Cannot use given ID as it already "
-                                       "exists in the controller session map: "
-                                       "%s" % session_uuid)
+            sid = iqr_session.uuid
+            if sid in self._iqr_sessions:
+                raise RuntimeError("Cannot use given session as its UUID "
+                                   "already exists in the controller session "
+                                   "map: %s" % sid)
 
-            self._iqr_sessions[session_uuid] = iqr_session
-            return session_uuid
+            self._iqr_sessions[sid] = iqr_session
+            if timeout > 0:
+                self._iqr_session_timeout[sid] = timeout
+                self._iqr_session_last_access[sid] = time.time()
+            return sid
 
     def get_session(self, session_uuid):
         """
@@ -105,6 +182,8 @@ class IqrController (SmqtkObject):
 
         """
         with self._map_rlock:
+            if session_uuid in self._iqr_session_timeout:
+                self._iqr_session_last_access = time.time()
             return self._iqr_sessions[session_uuid]
 
     def remove_session(self, session_uuid):
@@ -118,5 +197,7 @@ class IqrController (SmqtkObject):
 
         """
         with self._map_rlock:
-            with self._iqr_sessions[session_uuid]:
-                del self._iqr_sessions[session_uuid]
+            del self._iqr_sessions[session_uuid]
+            if session_uuid in self._iqr_session_timeout:
+                del self._iqr_session_timeout[session_uuid]
+                del self._iqr_session_last_access[session_uuid]

--- a/python/smqtk/web/iqr_service/__init__.py
+++ b/python/smqtk/web/iqr_service/__init__.py
@@ -180,10 +180,12 @@ class IqrService (SmqtkWebApp):
                 sid=sid,
             ), 409  # CONFLICT
 
-        iqrs = iqr_session.IqrSession()
+        iqrs = iqr_session.IqrSession(self.positive_seed_neighbors,
+                                      self.rel_index_config,
+                                      sid)
         with self.controller:
             with iqrs:
-                self.controller.add_session(iqrs, sid)
+                self.controller.add_session(iqrs)
                 self.session_classifiers[sid] = None
                 self.session_classifier_dirty[sid] = True
 

--- a/python/smqtk/web/iqr_service/__init__.py
+++ b/python/smqtk/web/iqr_service/__init__.py
@@ -71,7 +71,15 @@ class IqrService (SmqtkWebApp):
 
         merge_dict(c, {
             "iqr_service": {
-                "positive_seed_neighbors": 500,
+
+                "session_control": {
+                    "positive_seed_neighbors": 500,
+                    "session_expiration": {
+                        "enabled": True,
+                        "check_interval_seconds": 30,
+                        "session_timeout": 3600,
+                    }
+                },
 
                 "plugin_notes": {
                     "relevancy_index_config":
@@ -103,6 +111,7 @@ class IqrService (SmqtkWebApp):
                         "for the variety of classifiers that can potentially "
                         "be created via this utility.",
                 },
+
                 "plugins": {
                     "relevancy_index_config": c_rel_index,
                     "descriptor_index": plugin.make_config(
@@ -114,17 +123,18 @@ class IqrService (SmqtkWebApp):
                         plugin.make_config(get_classifier_impls()),
                     "classification_factory":
                         ClassificationElementFactory.get_default_config(),
-                }
+                },
+
             }
         })
         return c
 
     def __init__(self, json_config):
         super(IqrService, self).__init__(json_config)
+        sc_config = json_config['iqr_service']['session_control']
 
         # Initialize from config
-        self.positive_seed_neighbors = \
-            json_config['iqr_service']['positive_seed_neighbors']
+        self.positive_seed_neighbors = sc_config['positive_seed_neighbors']
         self.classifier_config = \
             json_config['iqr_service']['plugins']['classifier_config']
         self.classification_factory = \
@@ -146,7 +156,6 @@ class IqrService (SmqtkWebApp):
         self.rel_index_config = \
             json_config['iqr_service']['plugins']['relevancy_index_config']
 
-        self.controller = iqr_controller.IqrController()
         # Record of trained classifiers for a session. Session classifier
         # modifications locked under the parent session's global lock.
         #: :type: dict[collections.Hashable, smqtk.algorithms.SupervisedClassifier | None]
@@ -157,7 +166,22 @@ class IqrService (SmqtkWebApp):
         #: :type: dict[collections.Hashable, bool]
         self.session_classifier_dirty = {}
 
-        # TODO: Timer for removing a session if it hasn't been used in a while
+        def session_expire_callback(session):
+            """
+            :type session: smqtk.iqr.IqrSession
+            """
+            with session:
+                self._log.debug("Removing session %s classifier", session.uuid)
+                del self.session_classifiers[session.uuid]
+                del self.session_classifier_dirty[session.uuid]
+
+        self.controller = iqr_controller.IqrController(
+            sc_config['session_expiration']['enabled'],
+            sc_config['session_expiration']['check_interval_seconds'],
+            session_expire_callback
+        )
+        self.session_timeout = \
+            sc_config['session_expiration']['session_timeout']
 
     # PUT
     def init_session(self):
@@ -185,7 +209,7 @@ class IqrService (SmqtkWebApp):
                                       sid)
         with self.controller:
             with iqrs:
-                self.controller.add_session(iqrs)
+                self.controller.add_session(iqrs, self.session_timeout)
                 self.session_classifiers[sid] = None
                 self.session_classifier_dirty[sid] = True
 

--- a/python/smqtk/web/search_app/modules/iqr/iqr_search.py
+++ b/python/smqtk/web/search_app/modules/iqr/iqr_search.py
@@ -726,7 +726,7 @@ class IqrSearch (SmqtkObject, flask.Blueprint, Configurable):
                 iqr_sess = IqrSession(self._pos_seed_neighbors,
                                       self._rel_index_config,
                                       sid)
-                self._iqr_controller.add_session(iqr_sess, sid)
+                self._iqr_controller.add_session(iqr_sess)
                 self._iqr_work_dirs[iqr_sess.uuid] = \
                     osp.join(self.work_dir, sid)
                 safe_create_dir(self._iqr_work_dirs[iqr_sess.uuid])


### PR DESCRIPTION
When supporting a long-term service, IQR sessions and classifiers need to be cleaned otherwise RAM would get overrun by sessions that are no longer used. Session expiration has been added as an optional feature to the ``IqrController`` class that also allows registration of a callback function, which the IqrService leverages to also clean up classifiers (and other future associated resources).