### PR TITLE
Fix docker config typo + error catching

### DIFF
--- a/docker/smqtk_services/iqr.config.json
+++ b/docker/smqtk_services/iqr.config.json
@@ -111,7 +111,7 @@
                     "descr_cache_filepath": null,
                     "multiprocess_fetch": true
                 },
-                "type": "FlannNearestNeighborsIndex"
+                "type": "LibSvmHikRelevancyIndex"
             }
         },
         "positive_seed_neighbors": 500

--- a/docs/release_notes/v0.6.1.md
+++ b/docs/release_notes/v0.6.1.md
@@ -1,6 +1,6 @@
 SMQTK v0.6.1 Release Notes
 ==========================
-This is a minor release with a bug fix for the Docker wrapping of RESTful
+This is a minor release with a bug fixs for the Docker wrapping of RESTful
 services introduced in v0.6.0.
 
 Fixes since v0.6.0
@@ -10,3 +10,8 @@ Docker
 
   * Fixed issue where `smqtk_services.run_images.sh` wasn't properly pulling containers
     from Dockerhub.
+
+  * Fixed typo in default configuration files installed into the container.
+
+  * Fixed IQR service function layout to be more explicit in errors caught and
+    raised which maintaining thread safety.

--- a/python/smqtk/iqr/iqr_session.py
+++ b/python/smqtk/iqr/iqr_session.py
@@ -1,6 +1,5 @@
 import logging
-import multiprocessing
-import multiprocessing.pool
+import threading
 import uuid
 
 from smqtk.algorithms.relevancy_index import get_relevancy_index_impls
@@ -105,7 +104,7 @@ class IqrSession (SmqtkObject):
 
         """
         self.uuid = session_uid or str(uuid.uuid1()).replace('-', '')
-        self.lock = multiprocessing.RLock()
+        self.lock = threading.RLock()
 
         self.pos_seed_neighbors = int(pos_seed_neighbors)
 

--- a/python/smqtk/web/iqr_service/__init__.py
+++ b/python/smqtk/web/iqr_service/__init__.py
@@ -438,8 +438,8 @@ class IqrService (SmqtkWebApp):
 
             return make_response_json("Steps completed: %s" % msg, sid=sid), 201
 
-        except KeyError:
-            return make_response_json("session id '%s' not found" % sid,
+        except KeyError, e:
+            return make_response_json("session id %s not found" % e,
                                       sid=sid), 404
 
     # GET


### PR DESCRIPTION
This also solves a specific issue that @danlamanna brought to attention.  The issue is that the try catch is catching any KeyError that might get raised, and the message assumes that it must be a session ID related issue, which it might not be, such as in this case.  This try/catch message should probably be more specific in what it is trying to catch, or emit a more generally useful, and generic, message upon exception.