### PR TITLE
Fix caffe nondeterministic image loading

### DIFF
--- a/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
@@ -432,7 +432,8 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
                          itertools.repeat(self.data_layer, uid_num),
                          itertools.repeat(self.load_truncated_images, uid_num),
                          itertools.repeat(self.pixel_rescale, uid_num),
-                         use_multiprocessing=True)
+                         use_multiprocessing=True,
+                         ordered=True)
         )
 
         self._log.debug("Loading image bytes into network layer '%s'",

--- a/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
@@ -417,6 +417,10 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
         :type descr_elements: dict[collections.Hashable,
                                    smqtk.representation.DescriptorElement]
 
+        :param procs: The number of asynchronous processes to run for loading
+            images. This may be None to just use all available cores.
+        :type procs: None | int
+
         """
         self._log.debug("Updating network data layer shape (%d images)",
                         len(uuids4proc))
@@ -433,7 +437,8 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
                          itertools.repeat(self.load_truncated_images, uid_num),
                          itertools.repeat(self.pixel_rescale, uid_num),
                          use_multiprocessing=True,
-                         ordered=True)
+                         ordered=True,
+                         cores=procs)
         )
 
         self._log.debug("Loading image bytes into network layer '%s'",


### PR DESCRIPTION
Previous version had issues with processing descriptors using Caffe plugin. This was due to a non-deterministic return from the asynchronous image pixel loading / transforming when the parallel method was changed from using ``multiprocessing.Pool`` to ``smqtk.utils.parallel.parllel_map``. The ``ordered=True`` parameter has been added, causing results to compare to those before than function change.