### PR TITLE
Remove the automatic tailing of logs at end of docker script

### DIFF
--- a/docker/smqtk_services.run_images.sh
+++ b/docker/smqtk_services.run_images.sh
@@ -100,6 +100,3 @@ docker run -d --name ${DOCKER_SMQTK} \
     -p 12345:12345 \
     -p 12346:12346 \
     kitware/smqtk -b
-
-# Tail the expected logs
-tail -f smqtk_logs/compute_models.log smqtk_logs/smqtk.nnss.log smqtk_logs/smqtk.iqr.log


### PR DESCRIPTION
Removing the `tail -f`. I think the script should exit when things are started up, or at the very least it needs to be reworked so it waits for those log files to be created.