### PR TITLE
Revise in-memory descriptor element representation

### DIFF
--- a/docs/release_notes/v0.7.0.md
+++ b/docs/release_notes/v0.7.0.md
@@ -5,6 +5,11 @@ SMQTK v0.7.0 Release Notes
 Updates / New Features since v0.6.0
 -----------------------------------
 
+Descriptor Elements
+
+  * Revised implementation of in-memory representation, doing away with
+    global cache.
+
 Scripts
 
   * Add script to conveniently make Ball-tree hash index model given an

--- a/python/smqtk/tests/algorithms/classifier/test_libsvm.py
+++ b/python/smqtk/tests/algorithms/classifier/test_libsvm.py
@@ -20,10 +20,6 @@ if LibSvmClassifier.is_usable():
 
     class TestLibSvmClassifier (unittest.TestCase):
 
-        def tearDown(self):
-            # Clear MemoryElement content
-            DescriptorMemoryElement.MEMORY_CACHE = {}
-
         def test_no_save_model_pickle(self):
             # Test model preservation across pickling even without model cache
             # file paths set.

--- a/python/smqtk/tests/algorithms/nn_index/test_NNI_FLANN.py
+++ b/python/smqtk/tests/algorithms/nn_index/test_NNI_FLANN.py
@@ -20,9 +20,6 @@ if FlannNearestNeighborsIndex.is_usable():
 
         RAND_SEED = 42
 
-        def tearDown(self):
-            DescriptorMemoryElement.MEMORY_CACHE = {}
-
         def _make_inst(self, dist_method):
             """
             Make an instance of FlannNearestNeighborsIndex

--- a/python/smqtk/tests/algorithms/nn_index/test_NNI_abstract.py
+++ b/python/smqtk/tests/algorithms/nn_index/test_NNI_abstract.py
@@ -32,10 +32,6 @@ class DummySI (NearestNeighborsIndex):
 
 class TestSimilarityIndexAbstract (unittest.TestCase):
 
-    def setUp(self):
-        # Reset descriptor memory global cache before each test
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-
     def test_get_impls(self):
         # Some implementations should be returned
         m = get_nn_index_impls()

--- a/python/smqtk/tests/algorithms/nn_index/test_NNI_lsh.py
+++ b/python/smqtk/tests/algorithms/nn_index/test_NNI_lsh.py
@@ -23,9 +23,6 @@ class TestLshIndex (unittest.TestCase):
 
     RANDOM_SEED = 0
 
-    def tearDown(self):
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-
     def test_configuration(self):
         c = LSHNearestNeighborIndex.get_default_config()
 
@@ -115,8 +112,6 @@ class TestLshIndex (unittest.TestCase):
         for j in xrange(1, len(dists)):
             ntools.assert_greater(dists[j], dists[j-1])
 
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-
     def test_random_euclidean__itq__None(self):
         ftor, fit = self._make_ftor_itq()
         self._random_euclidean(ftor, None, fit)
@@ -174,8 +169,6 @@ class TestLshIndex (unittest.TestCase):
         r, dists = index.nn(q, dim)
         ntools.assert_equal(r[0], q)
         ntools.assert_equal(dists[0], 0.)
-
-        DescriptorMemoryElement.MEMORY_CACHE = {}
 
     def test_known_unit__euclidean__itq__None(self):
         ftor, fit = self._make_ftor_itq()

--- a/python/smqtk/tests/algorithms/relevancy_index/test_iqr_svm_hik.py
+++ b/python/smqtk/tests/algorithms/relevancy_index/test_iqr_svm_hik.py
@@ -39,10 +39,6 @@ class TestIqrSvmHik (unittest.TestCase):
         cls.q_neg = DescriptorMemoryElement('query', 1)
         cls.q_neg.set_vector(np.array([0,   0,   0, .5, .5], float))
 
-    @classmethod
-    def tearDownClass(cls):
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-
     def test_configuration(self):
         c = LibSvmHikRelevancyIndex.get_default_config()
         ntools.assert_in('descr_cache_filepath', c)

--- a/python/smqtk/tests/representation/DescriptorElement/test_DescriptorMemoryElement.py
+++ b/python/smqtk/tests/representation/DescriptorElement/test_DescriptorMemoryElement.py
@@ -12,16 +12,6 @@ __author__ = "paul.tunison@kitware.com"
 
 class TestDescriptorMemoryElement (unittest.TestCase):
 
-    def setUp(self):
-        # There should be nothing in the cache
-        assert not DescriptorMemoryElement.MEMORY_CACHE, \
-            "There were things in the memory element cache! %s" \
-            % DescriptorMemoryElement.MEMORY_CACHE
-
-    def tearDown(self):
-        # Reset MemoryElement cache
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-
     def test_configuration(self):
         default_config = DescriptorMemoryElement.get_default_config()
         ntools.assert_equal(default_config, {})
@@ -37,9 +27,6 @@ class TestDescriptorMemoryElement (unittest.TestCase):
         ntools.assert_equal(inst1, inst2)
 
     def test_pickle_dump_load(self):
-        # Wipe current cache
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-
         # Make a couple descriptors
         v1 = numpy.array([1, 2, 3])
         d1 = DescriptorMemoryElement('test', 0)
@@ -49,16 +36,8 @@ class TestDescriptorMemoryElement (unittest.TestCase):
         d2 = DescriptorMemoryElement('test', 1)
         d2.set_vector(v2)
 
-        ntools.assert_in(('test', 0), DescriptorMemoryElement.MEMORY_CACHE)
-        ntools.assert_in(('test', 1), DescriptorMemoryElement.MEMORY_CACHE)
-
         d1_s = cPickle.dumps(d1)
         d2_s = cPickle.dumps(d2)
-
-        # Wipe cache again
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-        ntools.assert_not_in(('test', 0), DescriptorMemoryElement.MEMORY_CACHE)
-        ntools.assert_not_in(('test', 1), DescriptorMemoryElement.MEMORY_CACHE)
 
         # Attempt reconstitution
         d1_r = cPickle.loads(d1_s)
@@ -66,10 +45,6 @@ class TestDescriptorMemoryElement (unittest.TestCase):
 
         numpy.testing.assert_array_equal(v1, d1_r.vector())
         numpy.testing.assert_array_equal(v2, d2_r.vector())
-
-        # Cache should now have those entries back in it
-        ntools.assert_in(('test', 0), DescriptorMemoryElement.MEMORY_CACHE)
-        ntools.assert_in(('test', 1), DescriptorMemoryElement.MEMORY_CACHE)
 
     def test_input_immutability(self):
         # make sure that data stored is not susceptible to shifts in the

--- a/python/smqtk/tests/representation/DescriptorIndex/test_DI_memory.py
+++ b/python/smqtk/tests/representation/DescriptorIndex/test_DI_memory.py
@@ -27,10 +27,6 @@ def random_descriptor():
 
 class TestMemoryDescriptorIndex (unittest.TestCase):
 
-    def tearDown(self):
-        # clear memory descriptor cache
-        DescriptorMemoryElement.MEMORY_CACHE = {}
-
     def test_is_usable(self):
         ntools.assert_equal(MemoryDescriptorIndex.is_usable(), True)
 

--- a/python/smqtk/tests/representation/test_DescriptorElementFactory.py
+++ b/python/smqtk/tests/representation/test_DescriptorElementFactory.py
@@ -116,4 +116,3 @@ class TestDescriptorElemFactory (unittest.TestCase):
         d = factory.new_descriptor('test', 'foo')
         ntools.assert_equal(d.type(), 'test')
         ntools.assert_equal(d.uuid(), 'foo')
-        DescriptorMemoryElement.MEMORY_CACHE = {}


### PR DESCRIPTION
Basically, simplify the in-memory descriptor element implementation. The original intention of in-memory descriptors is that there is no storage somewhere that's maintaining the vector. The previous implementation kept everything in memory in the background when the most common use case for using in-memory descriptors is just to store a vector locally and temporarilly.

This should also address the memory "leak" that can be seen when running a nearest-neighbor or iqr service over time when configured to use in-memory descriptor element generation (they're never destroyed/removed from global cache after generation).