### PR TITLE
Reverting a previous change to how the Caffe descriptor does async lo…

### DIFF
--- a/python/smqtk/algorithms/classifier/__init__.py
+++ b/python/smqtk/algorithms/classifier/__init__.py
@@ -85,8 +85,7 @@ class Classifier (SmqtkAlgorithm):
         :param procs: Explicit number of cores/thread/processes to use.
         :type procs: None | int
 
-        :param use_multiprocessing: Use ``multiprocessing.pool.Pool`` instead of
-            ``multiprocessing.pool.ThreadPool``.
+        :param use_multiprocessing: Use multiprocessing instead of threading.
         :type use_multiprocessing: bool
 
         :param ri: Progress reporting interval in seconds. Set to a value > 0 to


### PR DESCRIPTION
…ading

Previously changed to use the internally implemented streaming parallel
map function, which has caused heart-burn before.  This implementation
is still somewhat unstable and leads to an occasional dead-lock that has
yet to be diagnosed.  Since this code segment does not need streaming
functionality, we're revertting to just using multiprocessing.Pool.map,
which is known to be more stable (and probably faster).