### PR TITLE
Added some initial implicit imports to make core content available

### DIFF
--- a/docs/release_notes/v0.7.0.md
+++ b/docs/release_notes/v0.7.0.md
@@ -17,7 +17,8 @@ Classifier Interface
 
 Compute Functions
 
-  * Added minibatch kmeans based descriptor clustering function.
+  * Added minibatch kmeans based descriptor clustering function with CLI
+    interface.
 
 Descriptor Elements
 
@@ -47,6 +48,11 @@ Documentation
 
   * Standardized utility script definition of argument parser generation
     function for documentation use.
+
+Misc.
+
+  * Added algo/rep/iqr imports to top level ``__init__.py`` to make basic
+    functionality available without special imports.
 
 Scripts
 

--- a/python/smqtk/__init__.py
+++ b/python/smqtk/__init__.py
@@ -1,0 +1,5 @@
+from . import (
+    algorithms,
+    representation,
+    iqr
+)

--- a/python/smqtk/algorithms/__init__.py
+++ b/python/smqtk/algorithms/__init__.py
@@ -2,7 +2,15 @@ from smqtk.utils import SmqtkObject
 from smqtk.utils import Configurable, plugin
 
 
-__author__ = "paul.tunison@kitware.com"
+__all__ = [
+    'SmqtkAlgorithm',
+    'Classifier', 'SupervisedClassifier', 'get_classifier_impls',
+    'DescriptorGenerator', 'get_descriptor_generator_impls',
+    'NearestNeighborsIndex', 'get_nn_index_impls',
+    'HashIndex', 'get_hash_index_impls',
+    'LshFunctor', 'get_lsh_functor_impls',
+    'RelevancyIndex', 'get_relevancy_index_impls',
+]
 
 
 class SmqtkAlgorithm (SmqtkObject, Configurable, plugin.Pluggable):

--- a/python/smqtk/iqr/__init__.py
+++ b/python/smqtk/iqr/__init__.py
@@ -1,2 +1,7 @@
 from .iqr_session import IqrSession
 from .iqr_controller import IqrController
+
+__all__ = [
+    'IqrController',
+    'IqrSession',
+]

--- a/python/smqtk/representation/__init__.py
+++ b/python/smqtk/representation/__init__.py
@@ -1,6 +1,17 @@
 from smqtk.utils import Configurable, SmqtkObject
 
 
+__all__ = [
+    'SmqtkRepresentation',
+    'ClassificationElement', 'get_classification_element_impls',
+    'DataElement', 'get_data_element_impls',
+    'DataSet', 'get_data_set_impls',
+    'DescriptorElement', 'get_descriptor_element_impls',
+    'DescriptorIndex', 'get_descriptor_index_impls',
+    'ClassificationElementFactory', 'DescriptorElementFactory',
+]
+
+
 class SmqtkRepresentation (SmqtkObject, Configurable):
     """
     Interface for data representation interfaces and implementations.


### PR DESCRIPTION
Thanks @jeffbaumes for the suggestion. My only discomfort with this is that a bunch if stuff is them loaded, but maybe that's fine. I think I had initially looked at stuff like scikit-learn which didn't import most of its sub-modules when doing an ``import sklearn``. But then again, we're using plugins here for algorithms and backends, so ideally the bulk of loadable content lives in there, which is correctly not being loaded initially. I think I'll want to trim down some of the utility importing that occurs in ``smqtk/utils/__init__.py`` since I think most of it is not used from that scope.