### PR TITLE
Removed conda/pip separated requirements files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 # "Install" of SMQTK + immediate deps
 install:
   # install python dependencies to environment
-  - pip install -qr requirements.txt
+  - pip install -r requirements.txt
 
   # Build components of SMQTK
   - mkdir _build

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - export PATH=${LOCAL_ROOT}/bin:$PATH
   - export LD_LIBRARY_PATH=${LOCAL_ROOT}/lib:$LD_LIBRARY_PATH
   - mkdir ${LOCAL_ROOT}
-  # Setup local conda python
+  # Setup local conda python environment
   - wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -31,13 +31,11 @@ before_install:
   - conda update -q --all
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n smqtk-$TRAVIS_PYTHON_VERSION python=$TRAVIS_PYTHON_VERSION
-  - source activate smqtk-$TRAVIS_PYTHON_VERSION
 
 # "Install" of SMQTK + immediate deps
 install:
-  - conda install -q --file requirements.conda.txt
-  - pip install -qr requirements.pip.txt
+  # install python dependencies to environment
+  - pip install -qr requirements.txt
 
   # Build components of SMQTK
   - mkdir _build
@@ -46,8 +44,7 @@ install:
   - popd
 
   # Environment var export
-  - export PATH=$PWD/_build/TPL/install/bin:$PATH
-  - export PYTHONPATH=$PWD/_build/python:$PWD/_build/TPL/install/lib/python2.7/site-packages:$PYTHONPATH
+  - source _build/setup_env.build.sh
 
 # Run tests here
 script:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -65,7 +65,7 @@ Quick Start
     cd /where/things/should/go/
     git clone https://github.com/Kitware/SMQTK.git source
     # Install python dependencies to environment
-    pip install -r source/requirements.conda.txt -r source/requirements.pip.txt
+    pip install -r source/requirements.txt
     # SMQTK build
     mkdir build
     pushd build
@@ -110,55 +110,25 @@ To clone the repository locally:
 
 Installing Python dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-After deciding and activating what environment to install python packages to (system or a virtual), the python dependencies should be installed based on the :file:`requirements.*.txt` files found in the root of the source tree.
+After deciding and activating what environment to install python packages into (system or a virtual), the python dependencies should be installed based on the :file:`requirements.*.txt` files found in the root of the source tree.
 These files detail different dependencies, and their exact versions tested, for different components of SMQTK.
 
-These two files list the core required python packages (we'll explain why there are two files below):
+The the core required python packages are detailed in: :file:`requirements.txt`.
 
-* :file:`requirements.conda.txt`
-* :file:`requirements.pip.txt`
+In addition, if you wish to be able to build the Sphinx_ based documentation for the project: :file:`requirements.docs.txt`.
+These are separated because not everyone wishes or needs to build the documentation.
 
-In addition, if you wish to be able to build the Sphinx_ based documentation for the project there are two additional dependency files:
+Other optional dependencies and what plugins they correspond to are found in: :file:`requirements.optional.txt`
 
-* :file:`requirements.docs.conda.txt`
-* :file:`requirements.docs.pip.txt`
+Note that if :command:`conda` [#conda]_ is being used, not all packages listed in our requirements files may be found in :command:`conda`'s repository.
 
-Other optional dependencies and what plugins they correspond to are found in:
-
-* :file:`requirements.optional.txt`
-
-Required packages have been split up this way because :command:`conda` [#conda]_ does not provide all packages that :command:`pip` can.
-Further, not everyone wishes or needs to build the documentation.
-Optional dependencies are obviously optional and are separated from core dependencies for that reason.
-
-
-.. _installation-fromSource-InstallingPythonDeps-CondaAndPip:
-
-Installing with Conda and Pip
-"""""""""""""""""""""""""""""
-
-The three-step python dependency installation using both conda and pip, including separate environment creation, will look like the following:
+Installation of python dependencies via pip will look like the following:
 
 .. prompt:: bash
 
-    conda create -n <env_name> --file requirements.conda.txt [--file requirements.docs.conda.txt]
-    . activate <env_name>
-    pip install -r requirements.pip.txt [-r requirements.docs.pip.txt] [-r requirements.optional.txt]
+    pip install -r requirements.txt [-r requirements.docs.txt]
 
-
-Where the ``[ ... ]`` parts are optional, showing the use of multiple requirements files at once.
-
-
-Installing with just Pip
-""""""""""""""""""""""""
-
-Installation of python dependencies via pip only will look like the following:
-
-.. prompt:: bash
-
-    pip install -r requirements.conda.txt -r requirements.pip.txt [-r requirements.docs.conda.txt -r requirements.docs.pip.txt]
-
-Where the :file:`requirements.docs.*.txt` arguments are only needed if you intend to build the SMQTK documentation.
+Where the :file:`requirements.docs.txt` argument is only needed if you intend to build the SMQTK documentation.
 
 
 Building NumPy and SciPy

--- a/requirements.docs.conda.txt
+++ b/requirements.docs.conda.txt
@@ -1,2 +1,0 @@
-sphinx==1.4.1
-sphinx_rtd_theme==0.1.9

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -2,6 +2,8 @@
 --index-url https://pypi.python.org/simple/
 
 livereload==2.4.1
+sphinx==1.4.1
 sphinx-argparse==0.1.15
 sphinx-prompt==1.0.0
+sphinx_rtd_theme==0.1.9
 mock==2.0.0

--- a/requirements.pip.txt
+++ b/requirements.pip.txt
@@ -1,6 +1,0 @@
-# This is an implicit value, here for clarity
---index-url https://pypi.python.org/simple/
-
-flask-basicauth==0.2.0
-imageio==1.5
-nose-exclude==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,16 @@
+# This is an implicit value, here for clarity
+--index-url https://pypi.python.org/simple/
+
 coverage==4.2
 flask==0.11.1
+flask-basicauth==0.2.0
 flask-login==0.3.2
+imageio==1.5
 jinja2==2.8
 mock==2.0.0
 matplotlib==1.5.1
 nose==1.3.7
+nose-exclude==0.4.1
 numpy==1.11.1
 Pillow==3.3.1
 pymongo==3.3.0


### PR DESCRIPTION
Only retaining one requirements file for each separation as per the norm
with packages on PYPI. This is also motivated by wheel packages being
more commonly found via pip (e.g. with numpy, scipy, etc.), eliminating
the primary desire to separate package installations between conda/pip.

If it is desired to install packages through conda, users will have to
decide which packages they want to separate out.