### PR TITLE
Removed lingering references to conda-variant requirements txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,11 +75,6 @@ install(DIRECTORY   docs/
         DESTINATION share/doc/SMQTK
         )
 
-install(FILES requirements.conda.txt
-              requirements.pip.txt
-        DESTINATION share/smqtk
-        )
-
 # Should only be required for users installing to a non-standard location
 install(FILES "${SMQTK_BINARY_DIR}/setup_env.install.sh"
         DESTINATION .

--- a/docker/smqtk_services/Dockerfile
+++ b/docker/smqtk_services/Dockerfile
@@ -67,8 +67,7 @@ RUN mkdir -p /smqtk/build \
  && tar xf SMQTK-${SMQTK_VERSION}.tar.gz \
  && mv /SMQTK-${SMQTK_VERSION} /smqtk/source \
  && rm SMQTK-${SMQTK_VERSION}.tar.gz
-RUN pip install -r /smqtk/source/requirements.conda.txt \
-                -r /smqtk/source/requirements.pip.txt \
+RUN pip install -r /smqtk/source/requirements.txt
  && cd /smqtk/build \
  && cmake -DCMAKE_INSTALL_PREFIX:PATH=/smqtk/install /smqtk/source \
  && make install -j12 \


### PR DESCRIPTION
Removed requirements file installation as it seems redundant with
installation via pip, which resolves dependencies.