### PR TITLE
Fix element default and storage

### DIFF
--- a/docs/release_notes/v0.7.0.md
+++ b/docs/release_notes/v0.7.0.md
@@ -75,6 +75,9 @@ Scripts
   * Moved-command line scripts to the `smqtk.bin` sub-module in order to use
     ``setuptool`` support for cross-platform executable generation.
 
+  * ``classifier_kfold_validation`` utility now only uses
+    MemoryClassificationElement instead of letting it be configurable.
+
 
 Fixes since v0.6.2
 ------------------
@@ -93,6 +96,11 @@ Scripts
     did not report valid statistics.
 
   * Fixed deprecated import of ``flask-basicauth`` module.
+
+  * Fixed DescriptorFileElement cache-file save location directory when
+    configured to use subdirectories. Now no longer creates directories to
+    store only a single file. Previous file-element roots are not compatible
+    with this change and need to be re-ingested.
 
 Metrics
 

--- a/python/smqtk/algorithms/classifier/__init__.py
+++ b/python/smqtk/algorithms/classifier/__init__.py
@@ -50,7 +50,8 @@ class Classifier (SmqtkAlgorithm):
         :param d: Input descriptor to classify
         :type d: smqtk.representation.DescriptorElement
 
-        :param factory: Classification element factory
+        :param factory: Classification element factory. The default factory
+            yields MemoryClassificationElement instances.
         :type factory: smqtk.representation.ClassificationElementFactory
 
         :param overwrite: Recompute classification of the input descriptor and
@@ -83,7 +84,8 @@ class Classifier (SmqtkAlgorithm):
             collections.Iterable[smqtk.representation.DescriptorElement]
 
         :param factory: Classifier element factory to use for element
-            generation.
+            generation. The default factory yields MemoryClassificationElement
+            instances.
         :type factory: smqtk.representation.ClassificationElementFactory
 
         :param overwrite: Recompute classification of the input descriptor and

--- a/python/smqtk/bin/classifier_kfold_validation.py
+++ b/python/smqtk/bin/classifier_kfold_validation.py
@@ -79,6 +79,8 @@ from smqtk.representation import (
     ClassificationElementFactory,
     get_descriptor_index_impls,
 )
+from smqtk.representation.classification_element.memory import \
+    MemoryClassificationElement
 from smqtk.utils import (
     bin_utils,
     file_utils,
@@ -100,8 +102,6 @@ def default_config():
                 plugin.make_config(get_supervised_classifier_impls()),
             "descriptor_index":
                 plugin.make_config(get_descriptor_index_impls()),
-            "classification_factory":
-                ClassificationElementFactory.get_default_config(),
         },
         "cross_validation": {
             "truth_labels": None,
@@ -158,8 +158,12 @@ def classifier_kfold_validation():
     log.info("Loading classifier configuration")
     #: :type: dict
     classifier_config = config['plugins']['supervised_classifier']
-    classification_factory = ClassificationElementFactory.from_config(
-        config['plugins']['classification_factory']
+
+    # Always use in-memory ClassificationElement since we are retraining the
+    # classifier and don't want possible element caching
+    #: :type: ClassificationElementFactory
+    classification_factory = ClassificationElementFactory(
+        MemoryClassificationElement, {}
     )
 
     log.info("Loading truth data")

--- a/python/smqtk/representation/descriptor_element/local_elements.py
+++ b/python/smqtk/representation/descriptor_element/local_elements.py
@@ -134,13 +134,15 @@ class DescriptorFileElement (DescriptorElement):
             directory.
         :type save_dir: str | unicode
 
-        :param subdir_split: If a positive integer, this will cause us to store
-            the vector file in a subdirectory under the ``save_dir`` that was
-            specified. The integer value specifies the number of splits that we
-            will make in the stringification of this descriptor's UUID. If there
-            happen to be dashes in this stringification, we will remove them
-            (as would happen if given an uuid.UUID instance as the uuid
-            element).
+        :param subdir_split: If a positive integer and greater than 1, this will
+            cause us to store the vector file in a subdirectory under the
+            ``save_dir`` based on our ``uuid``. The integer value specifies the
+            number of splits that we will make in the stringification of this
+            descriptor's UUID. The last split component is left off when
+            determining the save directory (thus the >1 above).
+
+            Dashes are stripped from this string (as would happen if given an
+            uuid.UUID instance as the uuid element).
         :type subdir_split: None | int
 
         """
@@ -150,10 +152,10 @@ class DescriptorFileElement (DescriptorElement):
 
         # Saving components
         self._subdir_split = subdir_split
-        if subdir_split and int(subdir_split) > 0:
+        if subdir_split and int(subdir_split) > 1:
             save_dir = osp.join(self._save_dir,
                                 *partition_string(str(uuid).replace('-', ''),
-                                                  int(subdir_split))
+                                                  int(subdir_split))[:-1]
                                 )
         else:
             save_dir = self._save_dir

--- a/python/smqtk/tests/representation/DescriptorElement/test_DescriptorFileElement.py
+++ b/python/smqtk/tests/representation/DescriptorElement/test_DescriptorFileElement.py
@@ -37,15 +37,15 @@ class TestDescriptorFileElement (unittest.TestCase):
     def test_vec_filepath_generation(self):
         d = DescriptorFileElement('test', 'abcd', '/base', 4)
         ntools.assert_equal(d._vec_filepath,
-                            '/base/a/b/c/d/test.abcd.vector.npy')
+                            '/base/a/b/c/test.abcd.vector.npy')
 
         d = DescriptorFileElement('test', 'abcd', '/base', 2)
         ntools.assert_equal(d._vec_filepath,
-                            '/base/ab/cd/test.abcd.vector.npy')
+                            '/base/ab/test.abcd.vector.npy')
 
         d = DescriptorFileElement('test', 'abcd', '/base', 1)
         ntools.assert_equal(d._vec_filepath,
-                            '/base/abcd/test.abcd.vector.npy')
+                            '/base/test.abcd.vector.npy')
 
         d = DescriptorFileElement('test', 'abcd', '/base', 0)
         ntools.assert_equal(d._vec_filepath,
@@ -62,12 +62,12 @@ class TestDescriptorFileElement (unittest.TestCase):
     def test_vector_set(self, mock_scd, mock_save):
         d = DescriptorFileElement('test', 1234, '/base', 4)
         ntools.assert_equal(d._vec_filepath,
-                            '/base/1/2/3/4/test.1234.vector.npy')
+                            '/base/1/2/3/test.1234.vector.npy')
 
         v = numpy.zeros(16)
         d.set_vector(v)
-        mock_scd.assert_called_with('/base/1/2/3/4')
-        mock_save.assert_called_with('/base/1/2/3/4/test.1234.vector.npy', v)
+        mock_scd.assert_called_with('/base/1/2/3')
+        mock_save.assert_called_with('/base/1/2/3/test.1234.vector.npy', v)
 
     @mock.patch('smqtk.representation.descriptor_element.local_elements'
                 '.numpy.load')


### PR DESCRIPTION
Breaks backward compatibility with previous DescriptorFileElement storages. This can be resolved by traversing the directory tree and re-creating the elements from the cached file contents. Full UUIDs were and are still encoded in the file name.