### PR TITLE
Add minimal script for finding nearest neighbors

### DIFF
--- a/docs/release_notes/v0.7.0.md
+++ b/docs/release_notes/v0.7.0.md
@@ -78,6 +78,8 @@ Scripts
   * ``classifier_kfold_validation`` utility now only uses
     MemoryClassificationElement instead of letting it be configurable.
 
+  * Added script for finding nearest neighbors of a set of UUIDs given a
+    nearest neighbors index.
 
 Fixes since v0.6.2
 ------------------

--- a/python/smqtk/bin/nearest_neighbors.py
+++ b/python/smqtk/bin/nearest_neighbors.py
@@ -28,7 +28,9 @@ def get_cli_parser():
     parser.add_argument('-n', '--num',
                         default=10, metavar='INT', type=int,
                         help='Number of maximum nearest neighbors to return '
-                             'for each UUID.')
+                             'for each UUID, defaults to retrieving 10 nearest '
+                             'neighbors. Set to 0 to retrieve all nearest '
+                             'neighbors.')
     return parser
 
 
@@ -56,6 +58,9 @@ def main():
                                                        get_nn_index_impls())
 
     def nearest_neighbors(descriptor, n):
+        if n == 0:
+            n = len(nearest_neighbor_index)
+
         uuids, descriptors = nearest_neighbor_index.nn(descriptor, n)
         # Strip first result (itself) and create list of (uuid, distance)
         return zip([x.uuid() for x in uuids[1:]], descriptors[1:])
@@ -63,9 +68,8 @@ def main():
     if args.uuid_list is not None and not os.path.exists(args.uuid_list):
         log.error('Invalid file list path: %s', args.uuid_list)
         exit(103)
-    elif args.num <= 0:
-        # todo - support getting all nearest neighbors with num == 0?
-        log.error('Number of nearest neighbors must be > 0')
+    elif args.num < 0:
+        log.error('Number of nearest neighbors must be >= 0')
         exit(105)
 
     if args.uuid_list is not None:

--- a/python/smqtk/bin/nearest_neighbors.py
+++ b/python/smqtk/bin/nearest_neighbors.py
@@ -1,0 +1,88 @@
+"""
+Retrieve the nearest neighbors of a set of UUIDs.
+"""
+import logging
+import os
+import sys
+
+from smqtk.utils.bin_utils import (
+    basic_cli_parser,
+    utility_main_helper,
+)
+
+from smqtk.algorithms.nn_index import get_nn_index_impls
+from smqtk.utils import plugin
+
+
+__author__ = 'dan.lamanna@kitware.com'
+
+
+def get_cli_parser():
+    parser = basic_cli_parser(__doc__)
+    parser.add_argument('-u', '--uuid-list',
+                        default=None, metavar='PATH',
+                        help='Path to list of UUIDs to calculate nearest '
+                             'neighbors for. If empty, all UUIDs present '
+                             'in the descriptor index will be used.')
+
+    parser.add_argument('-n', '--num',
+                        default=10, metavar='INT', type=int,
+                        help='Number of maximum nearest neighbors to return '
+                        'for each UUID (excluding itself)')
+    return parser
+
+
+def get_default_config():
+    return {
+        'plugins': {
+            'nn_index': plugin.make_config(get_nn_index_impls())
+        }
+    }
+
+
+def main():
+    # Print help and exit if no arguments were passed
+    if len(sys.argv) == 1:
+        get_cli_parser().print_help()
+        sys.exit(1)
+
+    args = get_cli_parser().parse_args()
+    config = utility_main_helper(get_default_config, args)
+
+    log = logging.getLogger(__name__)
+    log.debug('Showing debug messages.')
+
+    nearest_neighbor_index = plugin.from_plugin_config(config['plugins']['nn_index'],
+                                                       get_nn_index_impls())
+
+    def nearest_neighbors(descriptor, n):
+        uuids, descriptors = nearest_neighbor_index.nn(descriptor, n)
+        # Strip first result (itself) and create list of (uuid, distance)
+        return zip([x.uuid() for x in uuids[1:]], descriptors[1:])
+
+    if args.uuid_list is not None and not os.path.exists(args.uuid_list):
+        log.error('Invalid file list path: %s', args.uuid_list)
+        exit(103)
+    elif args.num <= 0:
+        # todo - support getting all nearest neighbors with num == 0?
+        log.error('Number of nearest neighbors must be > 0')
+        exit(105)
+
+    if args.uuid_list is not None:
+        with open(args.uuid_list, 'r') as infile:
+            for line in infile:
+                descriptor = nearest_neighbor_index.descriptor_index \
+                                                   .get_descriptor(line.strip())
+                print(descriptor.uuid())
+                for neighbor in nearest_neighbors(descriptor, args.num + 1):
+                    print('%s,%f' % neighbor)
+    else:
+        for (uuid, descriptor) in nearest_neighbor_index.descriptor_index\
+                                                        .iteritems():
+            print(uuid)
+            for neighbor in nearest_neighbors(descriptor, args.num + 1):
+                print('%s,%f' % neighbor)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/smqtk/bin/nearest_neighbors.py
+++ b/python/smqtk/bin/nearest_neighbors.py
@@ -28,7 +28,7 @@ def get_cli_parser():
     parser.add_argument('-n', '--num',
                         default=10, metavar='INT', type=int,
                         help='Number of maximum nearest neighbors to return '
-                        'for each UUID (excluding itself)')
+                             'for each UUID.')
     return parser
 
 
@@ -74,13 +74,13 @@ def main():
                 descriptor = nearest_neighbor_index.descriptor_index \
                                                    .get_descriptor(line.strip())
                 print(descriptor.uuid())
-                for neighbor in nearest_neighbors(descriptor, args.num + 1):
+                for neighbor in nearest_neighbors(descriptor, args.num):
                     print('%s,%f' % neighbor)
     else:
         for (uuid, descriptor) in nearest_neighbor_index.descriptor_index\
                                                         .iteritems():
             print(uuid)
-            for neighbor in nearest_neighbors(descriptor, args.num + 1):
+            for neighbor in nearest_neighbors(descriptor, args.num):
                 print('%s,%f' % neighbor)
 
 

--- a/setup.py
+++ b/setup.py
@@ -200,6 +200,7 @@ setuptools.setup(
             'runApplication = smqtk.bin.runApplication:main',
             'summarizePlugins = smqtk.bin.summarizePlugins:main',
             'train_itq = smqtk.bin.train_itq:main',
+            'smqtk-nearest-neighbors = smqtk.bin.nearest_neighbors:main'
         ]
     }
 )


### PR DESCRIPTION
This adds a script under the alias `smqtk-nearest-neighbors` for finding
the nearest neighbors given a nearest neighbor index.

There are a number of ways this script could be improved in the future:
1) The computation could be parallelized with the caveat that the descriptor index is stored in a way that wouldn't get bogged down from random seeks.
2) Using a list of uuids should be batched to reduce the amount of queries to the descriptor index
3) Some level of support for picking up where it left off. This is harder to do since it's writing to stdout or a file, but maybe a limit/offset syntax, or in the future it can support storing them in a database table.
4) ~~Support for getting **all** nearest neighbors~~