### PR TITLE
Only use magic if the input filepath actually points to a real file

### DIFF
--- a/python/smqtk/representation/data_element/file_element.py
+++ b/python/smqtk/representation/data_element/file_element.py
@@ -51,13 +51,13 @@ class DataFileElement (DataElement):
         self._filepath = osp.expanduser(filepath)
 
         self._content_type = None
-        if magic:
+        if magic and osp.isfile(filepath):
             r = magic.detect_from_filename(filepath)
             self._content_type = r.mime_type
         elif tika_detector:
             try:
                 self._content_type = tika_detector.from_file(filepath)
-            except IOError, ex:
+            except IOError as ex:
                 self._log.warn("Failed tika.detector.from_file content type "
                                "detection (error: %s), falling back to file "
                                "extension",

--- a/python/smqtk/tests/representation/DataElement/test_DataFileElement.py
+++ b/python/smqtk/tests/representation/DataElement/test_DataFileElement.py
@@ -59,6 +59,9 @@ class TestDataFileElement (unittest.TestCase):
         source_filepath = '/path/to/file.png'
         target_dir = '/some/other/dir'
 
+        # If file-magic is available, skip it by getting ``isfile`` to
+        # temporarily return false.
+        mock_isfile.side_effect = lambda *args: False
         d = DataFileElement(source_filepath)
         fp = d.write_temp(temp_dir=target_dir)
 


### PR DESCRIPTION
``file-magic`` obviously fails if there are no bytes to introspect for a
file type. Fixed tests to pass when file-magic is installed.