### PR TITLE
Add incremetal caching to sieve_of_eratosthenes function

### DIFF
--- a/python/smqtk/tests/utils/test_factors.py
+++ b/python/smqtk/tests/utils/test_factors.py
@@ -83,6 +83,12 @@ class TestSoe (unittest.TestCase):
             [2, 3, 5, 7, 11, 13, 17, 19, 23]
         )
 
+    def test_60(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(60),
+            [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59]
+        )
+
     def test_100_primes(self):
         self.assertListEqual(factors.sieve_of_eratosthenes(541), p100)
 
@@ -112,3 +118,24 @@ class TestSoe (unittest.TestCase):
             actual_primes = factors.sieve_of_eratosthenes(r)
             self.assertListEqual(expected_primes, actual_primes,
                                  "Unexpected return for query value: %d" % r)
+
+
+class TestPrimeFactors (unittest.TestCase):
+
+    def test_600851475143(self):
+        # Some large number with weird prime factors.  Known values taken from
+        # wolfram alpha result (assuming WA is correct).
+        self.assertListEqual(
+            factors.prime_factors(600851475143),
+            [71, 839, 1471, 6857]
+        )
+
+
+class TestFactors (unittest.TestCase):
+
+    def test_600851475143(self):
+        self.assertSetEqual(
+            factors.factors(600851475143),
+            {1, 71, 839, 1471, 6857, 59569, 104441, 486847, 1234169, 5753023,
+             10086647, 87625999, 408464633, 716151937, 8462696833, 600851475143}
+        )

--- a/python/smqtk/tests/utils/test_factors.py
+++ b/python/smqtk/tests/utils/test_factors.py
@@ -26,8 +26,8 @@ class TestSoe (unittest.TestCase):
         """
         # Values copied from head of factors.py file, simulating initial import.
         factors._soe_prime_cache = [2, 3]
-        factors._soe_not_prime_map = {4: 2, 9: 3}
-        factors._soe_c = 4
+        factors._soe_not_prime_map = {9: 3}
+        factors._soe_c = 5
 
     def test_0(self):
         self.assertListEqual(
@@ -76,7 +76,13 @@ class TestSoe (unittest.TestCase):
             factors.sieve_of_eratosthenes(15),
             [2, 3, 5, 7, 11, 13]
         )
-        
+
+    def test_25(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(25),
+            [2, 3, 5, 7, 11, 13, 17, 19, 23]
+        )
+
     def test_100_primes(self):
         self.assertListEqual(factors.sieve_of_eratosthenes(541), p100)
 

--- a/python/smqtk/tests/utils/test_factors.py
+++ b/python/smqtk/tests/utils/test_factors.py
@@ -122,6 +122,27 @@ class TestSoe (unittest.TestCase):
 
 class TestPrimeFactors (unittest.TestCase):
 
+    def test_2(self):
+        # If the N requested is itself a prime value
+        self.assertListEqual(
+            factors.prime_factors(2),
+            [2]
+        )
+
+    def test_8(self):
+        self.assertListEqual(
+            factors.prime_factors(8),
+            [2, 2, 2]
+        )
+
+    def test_26345(self):
+        # Tests when trailing "remaining" value is not 1 because a prime was
+        # greater than the square-root of N.
+        self.assertListEqual(
+            factors.prime_factors(26345),
+            [5, 11, 479]
+        )
+
     def test_600851475143(self):
         # Some large number with weird prime factors.  Known values taken from
         # wolfram alpha result (assuming WA is correct).
@@ -138,4 +159,20 @@ class TestFactors (unittest.TestCase):
             factors.factors(600851475143),
             {1, 71, 839, 1471, 6857, 59569, 104441, 486847, 1234169, 5753023,
              10086647, 87625999, 408464633, 716151937, 8462696833, 600851475143}
+        )
+
+
+class TestFactorPairs (unittest.TestCase):
+
+    def test_600851475143(self):
+        self.assertListEqual(
+            factors.factor_pairs(600851475143),
+            [(1, 600851475143),
+             (71, 8462696833),
+             (839, 716151937),
+             (1471, 408464633),
+             (6857, 87625999),
+             (59569, 10086647),
+             (104441, 5753023),
+             (486847, 1234169)]
         )

--- a/python/smqtk/tests/utils/test_factors.py
+++ b/python/smqtk/tests/utils/test_factors.py
@@ -1,0 +1,108 @@
+import random
+import unittest
+
+from smqtk.utils import factors
+
+
+# First 100 known primes
+p100 = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,
+        67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137,
+        139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199,
+        211,  223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277,
+        281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359,
+        367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439,
+        443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521,
+        523, 541]
+
+
+class TestSoe (unittest.TestCase):
+    """
+    Unit tests for caching sieve of eratosthenes function.
+    """
+
+    def setUp(self):
+        """
+        Clear SoE caches before each test.
+        """
+        # Values copied from head of factors.py file, simulating initial import.
+        factors._soe_prime_cache = [2, 3]
+        factors._soe_not_prime_map = {4: 2, 9: 3}
+        factors._soe_c = 4
+
+    def test_0(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(0),
+            []
+        )
+
+    def test_1(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(1),
+            []
+        )
+
+    def test_2(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(2),
+            [2]
+        )
+
+    def test_3(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(3),
+            [2, 3]
+        )
+
+    def test_4(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(4),
+            [2, 3]
+        )
+
+    def test_5(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(5),
+            [2, 3, 5]
+        )
+
+    def test_7(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(7),
+            [2, 3, 5, 7]
+        )
+
+    def test_15(self):
+        self.assertListEqual(
+            factors.sieve_of_eratosthenes(15),
+            [2, 3, 5, 7, 11, 13]
+        )
+        
+    def test_100_primes(self):
+        self.assertListEqual(factors.sieve_of_eratosthenes(541), p100)
+
+    def test_100_with_caching(self):
+        # First ask for a value with 99 prime returns, then a value with 100 to
+        # see that we did get that new extra value.
+        self.assertListEqual(factors.sieve_of_eratosthenes(540), p100[:-1])
+        self.assertListEqual(factors.sieve_of_eratosthenes(541), p100)
+
+    def test_100_random_with_reset(self):
+        # Randomly test for prime values <= than 100th prime, resetting the
+        # cache each time.
+        for _ in range(100):
+            r = random.randint(0, max(p100)+1)
+            expected_primes = [p for p in p100 if p <= r]
+            self.setUp()  # Reset
+            actual_primes = factors.sieve_of_eratosthenes(r)
+            self.assertListEqual(expected_primes, actual_primes,
+                                 "Unexpected return for query value: %d" % r)
+
+    def test_100_random_with_caching(self):
+        # Randomly test for prime values <= than 100th prime, NOT resetting the
+        # cache each time.
+        for _ in range(100):
+            r = random.randint(0, max(p100) + 1)
+            expected_primes = [p for p in p100 if p <= r]
+            actual_primes = factors.sieve_of_eratosthenes(r)
+            self.assertListEqual(expected_primes, actual_primes,
+                                 "Unexpected return for query value: %d" % r)

--- a/python/smqtk/utils/factors.py
+++ b/python/smqtk/utils/factors.py
@@ -11,9 +11,9 @@ _soe_prime_cache = [2, 3]
 # Map of not-prime values and the increment after that value where the next
 # not-prime value may be found. This should only contain keys greater-than
 # the max(_prime_cache) value for finding further prime values.
-_soe_not_prime_map = {4: 2, 9: 3}
+_soe_not_prime_map = {9: 3}
 # The next value to continue iterating from.
-_soe_c = 4
+_soe_c = 5
 # TODO: Lock these globals when in use.
 
 
@@ -41,29 +41,37 @@ def sieve_of_eratosthenes(N):
         return [p for p in _soe_prime_cache if p <= N]
 
     # We need to find more prime values, so start with the least known
-    # not-prime and sieve our way up.
+    # not-prime and sieve our way up.  We maintain that _soe_c is always odd
+    # since no even value can be prime.
     while _soe_c <= N:
         if _soe_c in _soe_not_prime_map:
             # Get increment for the current non-prime value and record the next
-            # non-prime value, keeping this increment. Incrementing past N in
-            # order to main state in reused cache structure.
+            # odd non-prime value, keeping this increment. This may increment
+            # past N in order to main a correct state in the cache structure.
+            # Since we skip even values, _soe_c and its increment value will
+            # always be odd. Furthermore, two odd numbers added together will
+            # always be even so in order to the next odd not-prime value we need
+            # to add in increments of 2 times the base increment value.
             incr = _soe_not_prime_map[_soe_c]
-            nnp = _soe_c + incr
-            while (nnp in _soe_not_prime_map):
-                nnp += incr
+            incr2 = incr * 2
+            nnp = _soe_c + incr2
+            # Continue finding next divisible value that is not divisible by a
+            # higher prime.
+            while nnp in _soe_not_prime_map:
+                nnp += incr2
             _soe_not_prime_map[nnp] = incr
             # Remove _soe_c from map as it has been considered now.
             del _soe_not_prime_map[_soe_c]
         else:
             # _soe_c is a prime value: record it and add square of _soe_c to
             # not-prime-map (square of the prime is the first value not
-            # attaiable by multiplying preceeding prime value).
+            # attainable by multiplying preceding prime value).
             _soe_prime_cache.append(_soe_c)
             _soe_not_prime_map[_soe_c*_soe_c] = _soe_c
-        _soe_c += 1
+        _soe_c += 2
 
     # since we had to extend it, return a copy of the cache
-    return list( _soe_prime_cache )
+    return list(_soe_prime_cache)
 
 
 def prime_factors(N):

--- a/python/smqtk/utils/factors.py
+++ b/python/smqtk/utils/factors.py
@@ -38,12 +38,7 @@ def sieve_of_eratosthenes(N):
     if _soe_c > N:
         # We have already computed all primes up to N, so return cache-filled
         # list.
-        primes = []
-        for p in _soe_prime_cache:
-            if p > N:
-                break
-            primes.append(p)
-        return primes
+        return [p for p in _soe_prime_cache if p <= N]
 
     # We need to find more prime values, so start with the least known
     # not-prime and sieve our way up.

--- a/python/smqtk/utils/factors.py
+++ b/python/smqtk/utils/factors.py
@@ -6,62 +6,76 @@ import math
 __all__ = ["sieve_of_eratosthenes", "prime_factors", "factors", "factor_pairs"]
 
 
+# Set of known prime values
+_soe_prime_cache = [2, 3]
+# Map of not-prime values and the increment after that value where the next
+# not-prime value may be found. This should only contain keys greater-than
+# the max(_prime_cache) value for finding further prime values.
+_soe_not_prime_map = {4: 2, 9: 3}
+# The next value to continue iterating from.
+_soe_c = 4
+# TODO: Lock these globals when in use.
+
+
 def sieve_of_eratosthenes(N):
     """
     Return an ascending ordered list of prime numbers up to the given value,
     generated via the sieve of eratosthenes method.
 
-    TODO: Add starting offset so as to be able to get primes within a range
-            / add dynamic programming concepts.
+    TODO: Add starting offset so as to be able to get primes within a range.
+
+    :param N: Value to get prime values less-than-or-equal this value.
+    :return: List of prime integer values <= N.
+
     """
     # TODO: Optimization - all primes after 2 are odd, so special case when
     #           N == 2, else loop over and deal only with odd numbers.
+    global _soe_c
 
     # in case we get N as a string or something
     N = float(N)
 
-    # maps non-prime number to an increment value defining the next value after
-    # the key that is not a prime.
-    not_primes = {}
-    primes = []
+    if _soe_c > N:
+        # We have already computed all primes up to N, so return cache-filled
+        # list.
+        primes = []
+        for p in _soe_prime_cache:
+            if p > N:
+                break
+            primes.append(p)
+        return primes
 
-    c = 2
-    while c <= N:
-        if c in not_primes:
-            i = not_primes[c]
-            # next non-prime number. Need to skip entries already in not_primes
-            # so we don't interfere with recorded key-interval pairings
-            nnp = c + i
-            while (nnp in not_primes) and (nnp < N):
-                nnp += i
-            # npp may become >N, meaning results of this interval have already
-            # been fully covered, and we can safely assign it out of the range
-            # of N as we know we won't be looking past N at the most in the map.
-            not_primes[nnp] = i
-            # Won't be looking at c again, so we can remove it from the map to
-            # save memory
-            del not_primes[c]
+    # We need to find more prime values, so start with the least known
+    # not-prime and sieve our way up.
+    while _soe_c <= N:
+        if _soe_c in _soe_not_prime_map:
+            # Get increment for the current non-prime value and record the next
+            # non-prime value, keeping this increment. Incrementing past N in
+            # order to main state in reused cache structure.
+            incr = _soe_not_prime_map[_soe_c]
+            nnp = _soe_c + incr
+            while (nnp in _soe_not_prime_map):
+                nnp += incr
+            _soe_not_prime_map[nnp] = incr
+            # Remove _soe_c from map as it has been considered now.
+            del _soe_not_prime_map[_soe_c]
         else:
-            primes.append(c)
-            # The lowest value that will
-            c_squared = c*c
-            if c_squared <= N:
-                not_primes[c_squared] = c
-        c += 1
+            # _soe_c is a prime value: record it and add square of _soe_c to
+            # not-prime-map (square of the prime is the first value not
+            # attaiable by multiplying preceeding prime value).
+            _soe_prime_cache.append(_soe_c)
+            _soe_not_prime_map[_soe_c*_soe_c] = _soe_c
+        _soe_c += 1
 
-    return primes
+    # since we had to extend it, return a copy of the cache
+    return list( _soe_prime_cache )
 
 
 def prime_factors(N):
     """
     Returns ordered ascending prime factors of N.
-
-    TODO: Could add caching of answers for quicker successive responses.
-          Could make this recursive and leverage dynamic programming concepts
-            -> find a prime factor, call prime_factors on remaining divisor
     """
     sqrt_N = math.sqrt(N)
-    # sqrt_N = math.sqrt(N) + math.log10(N)
     primes = sieve_of_eratosthenes(sqrt_N)
 
     # prime factorize N
@@ -101,7 +115,7 @@ def factors(N):
 
     # using sorted as we want to return a list, and directly converting a set
     # to a list causes things to be out of sequential order.
-    return sorted(ftors)
+    return ftors
 
 
 def factor_pairs(N):

--- a/python/smqtk/utils/factors.py
+++ b/python/smqtk/utils/factors.py
@@ -25,7 +25,10 @@ def sieve_of_eratosthenes(N):
     TODO: Add starting offset so as to be able to get primes within a range.
 
     :param N: Value to get prime values less-than-or-equal this value.
+    :type N: int | float | str
+
     :return: List of prime integer values <= N.
+    :rtype: list[int]
 
     """
     # TODO: Optimization - all primes after 2 are odd, so special case when
@@ -77,13 +80,22 @@ def sieve_of_eratosthenes(N):
 def prime_factors(N):
     """
     Returns ordered ascending prime factors of N.
+
+    If a floating point value is passed, we cast it to an integer.
+
+    :param N: Value to get the prime factors list of.
+    :type N: int
+
+    :returns: List of prime factors in ascending order.
+    :rtype: list[int]
+
     """
     sqrt_N = math.sqrt(N)
     primes = sieve_of_eratosthenes(sqrt_N)
 
     # prime factorize N
     p_factors = []
-    remaining = N
+    remaining = int(N)
     for p in primes:
         # Short-cut loop exit when we know we cant factorize any more
         if remaining == 1:
@@ -102,6 +114,13 @@ def prime_factors(N):
 def factors(N):
     """
     Return divisors/factors of N.
+
+    :param N: Value to get the factors of.
+    :type N: int
+
+    :returns: Set of factors for value N.
+    :rtype: set[int]
+
     """
     pf = prime_factors(N)
     # noinspection PySetFunctionToLiteral
@@ -123,11 +142,19 @@ def factors(N):
 
 def factor_pairs(N):
     """
-    Return a list of factor pairs of N, whose individual product produce N.
+    Return a list of factor pairs of N, whose individual products produce N.
+
+    :param N: Value to get the factor pairs for.
+    :type N: int
+
+    :returns: List of factor pairs ordered by minimum factor value.
+    :rtype: list[(int, int)]
+
     """
-    ftors = factors(N)
-    # since what comes out of factors is sorted, step indices from the edges
-    # towards the center, pairing the edges to produce factor pairs.
+    # Order factors in order to match outside edges of shrinking bounds.
+    ftors = sorted(factors(N))
+    # Step indices from the edges towards the center, pairing the edges to
+    # produce factor pairs.
     i = 0
     j = len(ftors) - 1
     pairs = []


### PR DESCRIPTION
Randomly found some time to add a caching optimization to the sieve-of-eratosthenes function for finding primes when I was playing with coding problems on codewars. This improvement causes successive calls to the function, and other functions that use soe, to be faster on average.

Still needs locking around globals still for thread safety.