### PR TITLE
Dev/fix libsvm build command

### DIFF
--- a/TPL/CMakeLists.txt
+++ b/TPL/CMakeLists.txt
@@ -25,6 +25,11 @@ endif()
 # libSVM
 #
 if (SMQTK_BUILD_LIBSVM)
+  # Required a make command to build. Required its existance.
+  if( NOT MAKE_EXECUTABLE )
+    message( FATAL_ERROR "Could not find 'make', required to build libsvm." )
+  endif()
+
   set(libSVM_DIR "${CMAKE_CURRENT_LIST_DIR}/libsvm-3.1-custom")
   ExternalProject_Add(libSVM
     PREFIX            "${TPL_BUILD_PREFIX}"

--- a/TPL/CMakeLists.txt
+++ b/TPL/CMakeLists.txt
@@ -10,6 +10,17 @@ option(SMQTK_BUILD_FLANN "Enable building of FLANN." ON)
 #   TPL_PYTHON_SP     - relative path of standarad Python site-packages dir
 
 
+# Pick "make" executable based on generator chosen or environment variable
+# set.
+if (CMAKE_GENERATOR MATCHES ".*Makefiles")
+  set(MAKE_EXECUTABLE "$(MAKE)")
+elseif(NOT "#@$ENV{MAKE}" STREQUAL "#@")
+  set(MAKE_EXECUTABLE $ENV{MAKE})
+else()
+  find_program(MAKE_EXECUTABLE make)
+endif()
+
+
 ###
 # libSVM
 #
@@ -20,7 +31,7 @@ if (SMQTK_BUILD_LIBSVM)
     SOURCE_DIR        "${libSVM_DIR}"
     CONFIGURE_COMMAND ""
     BUILD_IN_SOURCE   1
-    BUILD_COMMAND     $(MAKE) lib
+    BUILD_COMMAND     ${MAKE_EXECUTABLE} lib
     INSTALL_DIR       "${TPL_LOCAL_INSTALL}"
     INSTALL_COMMAND   "${CMAKE_COMMAND}" -E make_directory "${TPL_LOCAL_INSTALL}/lib"
             COMMAND   "${CMAKE_COMMAND}" -E make_directory "${TPL_LOCAL_INSTALL}/include"


### PR DESCRIPTION
Be a little more robust when trying to build libsvm instead of always assuming a Makefile-type generator is being used.  We now check appropriately for a "make" executable similar to how [fletch](https://github.com/Kitware/fletch/blob/2618b49/CMakeLists.txt#L186-L192) does it.

Addresses issue #317 .