### PR TITLE
Vp tree hash index

### DIFF
--- a/docs/release_notes/v0.7.0.md
+++ b/docs/release_notes/v0.7.0.md
@@ -36,6 +36,10 @@ Descriptor Generator
   * Removed lingering assumption of ``pyflann`` module presence in
     ``colordescriptor.py``.
 
+Hash Index
+
+  * Added vantage point trees as a hash index type.
+
 Docker
 
   * Revised default IQR service configuration file to take into account
@@ -56,6 +60,9 @@ Misc.
 
   * Added algo/rep/iqr imports to top level ``__init__.py`` to make basic
     functionality available without special imports.
+
+  * Optimized methods for converting from bit vectors to Python long
+    representations and back.
 
 Scripts
 

--- a/python/smqtk/algorithms/nn_index/hash_index/vptree.py
+++ b/python/smqtk/algorithms/nn_index/hash_index/vptree.py
@@ -1,0 +1,116 @@
+import os
+
+from smqtk.algorithms.nn_index.hash_index import HashIndex
+from smqtk.utils.vptree import vp_make_tree, vp_knn_recursive
+from smqtk.utils.bit_utils import (
+    bit_vector_to_int_large,
+    int_to_bit_vector_large,
+)
+from smqtk.utils.metrics import hamming_distance
+
+
+__author__ = "william.p.hicks@gmail.com"
+
+
+class VPTreeHashIndex (HashIndex):
+    """
+    Index using a basic vantage point tree
+    """
+
+    @classmethod
+    def is_usable(cls):
+        return True
+
+    def __init__(self, file_cache=None, random_seed=None):
+        """
+        Initialize vantage point tree hash index
+
+        :param file_cache: Optional path to a file to cache our index to.
+        :type file_cache: str
+
+        """
+        super(VPTreeHashIndex, self).__init__()
+        self.file_cache = file_cache
+        self.random_seed = random_seed
+        self.vpt = None
+        self.load_cache()
+
+    def get_config(self):
+        return {
+            'file_cache': self.file_cache,
+            'random_seed': self.random_seed,
+        }
+
+    def load_cache(self):
+        """
+        Load from file cache if we have one
+        """
+        if self.file_cache and os.path.isfile(self.file_cache):
+            raise NotImplementedError
+
+    def save_cache(self):
+        """
+        save to file cache if configures
+        """
+        if self.file_cache:
+            raise NotImplementedError
+
+    def count(self):
+        if self.vpt is not None:
+            return self.vpt.num_descendants + 1
+        else:
+            return 0
+
+    def build_index(self, hashes):
+        """
+        Build the index with the give hash codes (bit-vectors).
+
+        Subsequent calls to this method should rebuild the index, not add to
+        it, or raise an exception to as to protect the current index.
+
+        :raises ValueError: No data available in the given iterable.
+
+        :param hashes: Iterable of descriptor elements to build index
+            over.
+        :type hashes: collections.Iterable[numpy.ndarray[bool]]
+
+        """
+        hashes_as_ints = map(bit_vector_to_int_large, hashes)
+        if not hashes_as_ints:
+            raise ValueError("No hashes given to index.")
+        self.vpt = vp_make_tree(hashes_as_ints, hamming_distance,
+                                r_seed=self.random_seed)
+        self.save_cache()
+
+    def nn(self, h, n=1):
+        """
+        Return the nearest `N` neighbors to the given hash code.
+
+        Distances are in the range [0,1] and are the percent different each
+        neighbor hash is from the query, based on the number of bits contained
+        in the query.
+
+        :param h: Hash code to compute the neighbors of. Should be the same bit
+            length as indexed hash codes.
+        :type h: numpy.ndarray[bool]
+
+        :param n: Number of nearest neighbors to find.
+        :type n: int
+
+        :raises ValueError: No index to query from.
+
+        :return: Tuple of nearest N hash codes and a tuple of the distance
+            values to those neighbors.
+        :rtype: (tuple[numpy.ndarray[bool], tuple[float])
+
+        """
+        super(VPTreeHashIndex, self).nn(h, n)
+        h_int = bit_vector_to_int_large(h)
+        neighbors, dists = vp_knn_recursive(
+            h_int, n, self.vpt, hamming_distance)
+        bits = len(h)
+        neighbors = [
+            int_to_bit_vector_large(neighbor, bits=bits)
+            for neighbor in neighbors
+        ]
+        return neighbors, dists

--- a/python/smqtk/tests/algorithms/nn_index/hash_index/test_HI_vptree.py
+++ b/python/smqtk/tests/algorithms/nn_index/hash_index/test_HI_vptree.py
@@ -1,0 +1,83 @@
+import os
+import tempfile
+import unittest
+
+import mock
+import nose.tools
+import numpy
+
+from smqtk.algorithms.nn_index.hash_index.vptree import \
+    VPTreeHashIndex
+
+
+__author__ = "william.p.hicks@gmail.com"
+
+
+if VPTreeHashIndex.is_usable():
+
+    class TestVPTreeHashIndex (unittest.TestCase):
+
+        def test_file_cache_type(self):
+            # Requires .npz file
+            nose.tools.assert_raises(
+                ValueError,
+                VPTreeHashIndex,
+                file_cache='some_file.txt'
+            )
+
+            VPTreeHashIndex(file_cache='some_file.npz')
+
+        @mock.patch('smqtk.algorithms.nn_index.hash_index.vptree.numpy.savez')
+        def test_save_model_no_cache(self, m_savez):
+            vpt = VPTreeHashIndex()
+            m = numpy.random.randint(0, 2, size=(1000, 256))
+            vpt.build_index(m)
+            nose.tools.assert_false(m_savez.called)
+
+        @mock.patch('smqtk.algorithms.nn_index.hash_index.vptree.numpy.savez')
+        def test_save_model_with_cache(self, m_savez):
+            vpt = VPTreeHashIndex('some_file.npz')
+            m = numpy.random.randint(0, 2, size=(1000, 256), dtype='bool')
+            vpt.build_index(m)
+            nose.tools.assert_true(m_savez.called)
+            nose.tools.assert_equal(m_savez.call_count, 1)
+
+        def test_model_reload(self):
+            fd, fp = tempfile.mkstemp('.npz')
+            os.close(fd)
+            os.remove(fp)  # shouldn't exist before construction
+            try:
+                vpt = VPTreeHashIndex(file_cache=fp)
+                m = numpy.random.randint(0, 2, size=(1000, 256), dtype='bool')
+                vpt.build_index(m)
+                q = numpy.random.randint(0, 2, 256, dtype='bool')
+                vpt_neighbors, vpt_dists = vpt.nn(q, 10)
+
+                vpt2 = VPTreeHashIndex(file_cache=fp)
+                vpt2_neighbors, vpt2_dists = vpt2.nn(q, 10)
+
+                nose.tools.assert_is_not(vpt, vpt2)
+                nose.tools.assert_is_not(vpt.vpt, vpt2.vpt)
+                numpy.testing.assert_equal(vpt2_neighbors, vpt_neighbors)
+                numpy.testing.assert_equal(vpt2_dists, vpt_dists)
+            finally:
+                os.remove(fp)
+
+        def test_invalid_build(self):
+            vpt = VPTreeHashIndex()
+            nose.tools.assert_raises(
+                ValueError,
+                vpt.build_index,
+                []
+            )
+
+        def test_get_config(self):
+            vpt = VPTreeHashIndex()
+            vpt_c = vpt.get_config()
+
+            nose.tools.assert_equal(len(vpt_c), 3)
+            nose.tools.assert_in('file_cache', vpt_c)
+            nose.tools.assert_in('random_seed', vpt_c)
+            nose.tools.assert_in('tree_type', vpt_c)
+
+            nose.tools.assert_is(vpt_c['file_cache'], None)

--- a/python/smqtk/tests/utils/test_bit_utils.py
+++ b/python/smqtk/tests/utils/test_bit_utils.py
@@ -1,0 +1,73 @@
+from __future__ import print_function
+
+import numpy
+import unittest
+
+from six.moves import range
+
+from smqtk.utils.bit_utils import (
+    bit_vector_to_int,
+    int_to_bit_vector,
+    bit_vector_to_int_large,
+    int_to_bit_vector_large,
+)
+
+
+class TestLargeBitVecConversions (unittest.TestCase):
+
+    def setUp(self):
+        one_bits = (254, 253, 2, 1, 0)
+        standard_bits = [int(i in one_bits) for i in range(256)]
+        self.boolvec = numpy.array(standard_bits, dtype='bool')
+        self.intvec = numpy.array(standard_bits, dtype='int')
+        self.int_rep = sum(2L**(255 - x) for x in one_bits)
+        self.rev_int_rep = sum(2L**x for x in one_bits)
+
+    def test_bit_vector_to_int_large(self):
+        self.assertEqual(self.int_rep, bit_vector_to_int_large(self.boolvec))
+        self.assertEqual(self.int_rep, bit_vector_to_int_large(self.intvec))
+        self.assertEqual(
+            self.rev_int_rep, bit_vector_to_int_large(self.boolvec[::-1])
+        )
+        self.assertEqual(
+            self.rev_int_rep, bit_vector_to_int_large(self.intvec[::-1])
+        )
+
+    def test_int_to_bit_vector_large(self):
+        numpy.testing.assert_array_equal(
+            self.boolvec, int_to_bit_vector_large(self.int_rep, bits=256)
+        )
+        numpy.testing.assert_array_equal(
+            self.boolvec[::-1],
+            int_to_bit_vector_large(self.rev_int_rep, bits=256)
+        )
+
+
+class TestBitVecConversions (unittest.TestCase):
+
+    def setUp(self):
+        one_bits = (62, 61, 2, 1, 0)
+        standard_bits = [int(i in one_bits) for i in range(64)]
+        self.boolvec = numpy.array(standard_bits, dtype='bool')
+        self.intvec = numpy.array(standard_bits, dtype='int')
+        self.int_rep = sum(2L**(63 - x) for x in one_bits)
+        self.rev_int_rep = sum(2L**x for x in one_bits)
+
+    def test_bit_vector_to_int(self):
+        self.assertEqual(self.int_rep, bit_vector_to_int(self.boolvec))
+        self.assertEqual(self.int_rep, bit_vector_to_int(self.intvec))
+        self.assertEqual(
+            self.rev_int_rep, bit_vector_to_int(self.boolvec[::-1])
+        )
+        self.assertEqual(
+            self.rev_int_rep, bit_vector_to_int(self.intvec[::-1])
+        )
+
+    def test_int_to_bit_vector(self):
+        numpy.testing.assert_array_equal(
+            self.boolvec, int_to_bit_vector(self.int_rep)
+        )
+        numpy.testing.assert_array_equal(
+            self.boolvec[::-1],
+            int_to_bit_vector(self.rev_int_rep, bits=64)
+        )

--- a/python/smqtk/tests/utils/test_bit_utils.py
+++ b/python/smqtk/tests/utils/test_bit_utils.py
@@ -46,11 +46,11 @@ class TestLargeBitVecConversions (unittest.TestCase):
 class TestBitVecConversions (unittest.TestCase):
 
     def setUp(self):
-        one_bits = (62, 61, 2, 1, 0)
-        standard_bits = [int(i in one_bits) for i in range(64)]
+        one_bits = (61, 60, 2, 1, 0)
+        standard_bits = [int(i in one_bits) for i in range(63)]
         self.boolvec = numpy.array(standard_bits, dtype='bool')
         self.intvec = numpy.array(standard_bits, dtype='int')
-        self.int_rep = sum(2L**(63 - x) for x in one_bits)
+        self.int_rep = sum(2L**(62 - x) for x in one_bits)
         self.rev_int_rep = sum(2L**x for x in one_bits)
 
     def test_bit_vector_to_int(self):
@@ -69,5 +69,5 @@ class TestBitVecConversions (unittest.TestCase):
         )
         numpy.testing.assert_array_equal(
             self.boolvec[::-1],
-            int_to_bit_vector(self.rev_int_rep, bits=64)
+            int_to_bit_vector(self.rev_int_rep, bits=63)
         )

--- a/python/smqtk/tests/utils/test_vptree.py
+++ b/python/smqtk/tests/utils/test_vptree.py
@@ -9,7 +9,12 @@ from six.moves import range
 import nose.tools
 import numpy
 
-from smqtk.utils.vptree import *
+from smqtk.utils.vptree import (
+    vp_make_tree, vps_make_tree, vpsb_make_tree,
+    vp_knn_recursive, vp_knn_iterative, vp_knn_iterative_heapq,
+    vps_knn_recursive, vps_knn_iterative_heapq, vpsb_knn_recursive,
+    VpNode, VpsNode, VpsbNode
+)
 
 
 D_COUNT = 0
@@ -25,12 +30,12 @@ def dist_func_counter(d):
 
 
 def print_tree(tree, offset=0):
-    ret = "{} {}".format("|"*offset, tree)
+    ret = "{} {}".format("|" * offset, tree)
     if tree is not None:
         ret = "\n".join((
             ret,
-            print_tree(tree.left, offset=offset+1),
-            print_tree(tree.right, offset=offset+1)
+            print_tree(tree.left, offset=offset + 1),
+            print_tree(tree.right, offset=offset + 1)
         ))
     return ret
 
@@ -170,7 +175,6 @@ class TestVpTree (unittest.TestCase, TestVpBase):
         )
         assert_vptrees_equal(vpt, vpt2)
 
-
     def test_knn_recursive(self):
         S = self._make_sequential_set()
         c = {}
@@ -182,7 +186,6 @@ class TestVpTree (unittest.TestCase, TestVpBase):
         q = 0  # we s
         nbors, dists = vp_knn_recursive(q, 10, root, dist_func)
         self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-        print("debug")
 
         # With query of "len(S)", we should see reverse sequence from S from
         # high to low.
@@ -212,8 +215,8 @@ class TestVpTree (unittest.TestCase, TestVpBase):
         q = max(S)
         nbors, dists = vp_knn_iterative(q, 10, root, dist_func)
         self.assertSequenceEqual(nbors,
-                                 [q,   q-1, q-2, q-3, q-4,
-                                  q-5, q-6, q-7, q-8, q-9])
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])
 
     def test_knn_iterative_heapq(self):
         S = self._make_sequential_set()
@@ -233,8 +236,8 @@ class TestVpTree (unittest.TestCase, TestVpBase):
         q = max(S)
         nbors, dists = vp_knn_iterative_heapq(q, 10, root, dist_func)
         self.assertSequenceEqual(nbors,
-                                 [q,   q-1, q-2, q-3, q-4,
-                                  q-5, q-6, q-7, q-8, q-9])
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])
 
 
 class TestVpsTree (unittest.TestCase, TestVpBase):
@@ -303,8 +306,8 @@ class TestVpsTree (unittest.TestCase, TestVpBase):
         q = max(S)
         nbors, dists = vps_knn_iterative_heapq(q, 10, root, dist_func)
         self.assertSequenceEqual(nbors,
-                                 [q,   q-1, q-2, q-3, q-4,
-                                  q-5, q-6, q-7, q-8, q-9])
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])
 
     def test_make_deduplicate(self):
         # Make set with duplicate elements (two copies of each integer).
@@ -337,19 +340,19 @@ class TestVpsbTree (unittest.TestCase, TestVpBase):
         c = {}
         dist_func = self._make_dist_func(max(S), c)
 
-        root = vpsb_make_tree(S, dist_func, 2, r_seed=self.RAND_SEED)
+        vpsb_make_tree(S, dist_func, 2, r_seed=self.RAND_SEED)
         # Calls to distance function should be <= O(n*(log(n)/log(2)))
         max_expected_calls = len(S) * math.log(len(S), 2)
         self.assertLessEqual(c['count'], max_expected_calls)
         c['count'] = 0
 
-        root = vpsb_make_tree(S, dist_func, 3, r_seed=self.RAND_SEED)
+        vpsb_make_tree(S, dist_func, 3, r_seed=self.RAND_SEED)
         # Calls to distance function should be <= O(n*(log(n)/log(3)))
         max_expected_calls = len(S) * math.log(len(S), 3)
         self.assertLessEqual(c['count'], max_expected_calls)
         c['count'] = 0
 
-        root = vpsb_make_tree(S, dist_func, 9, r_seed=self.RAND_SEED)
+        vpsb_make_tree(S, dist_func, 9, r_seed=self.RAND_SEED)
         # Calls to distance function should be <= O(n*(log(n)/log(9)))
         # TODO: Adding a 10% fudge factor here because its clocking in at a
         #       little over expected runtime and not sure why at the moment,

--- a/python/smqtk/tests/utils/test_vptree.py
+++ b/python/smqtk/tests/utils/test_vptree.py
@@ -1,0 +1,331 @@
+from __future__ import print_function
+
+import math
+import random
+import unittest
+
+from six.moves import range
+
+from smqtk.utils.vptree import *
+
+
+D_COUNT = 0
+
+
+def dist_func_counter(d):
+    """
+    Increment a count in a dictionary instance.
+    :param d: Dictionary tracker.
+    :type d: dict
+    """
+    d['count'] = d.get('count', 0) + 1
+
+
+class TestVpBase (object):
+
+    P = 1
+    RAND_SEED = 0
+
+    def _make_sequential_set(self):
+        """
+        Make shuffled set of sequential numbers based on set P value
+        (power of 2)
+        """
+        s = list(range(2**self.P))
+        random.seed(self.RAND_SEED)
+        random.shuffle(s)
+        return s
+
+    @staticmethod
+    def _make_dist_func(s_max, counter):
+        """
+        Dummy distance function measuring delta between values, normalizing to
+        set max value.
+        """
+        def dummy_dist_func(a, b):
+            dist_func_counter(counter)
+            return abs(a - b) / float(s_max)
+        return dummy_dist_func
+
+
+class TestVpTree (unittest.TestCase, TestVpBase):
+
+    P = 12
+
+    def test_make_tree(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        vp_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+        # Calls to distance function should be <= O(n*log(n))
+        max_expected_calls = len(S) * math.log(len(S), 2)
+        self.assertLessEqual(c['count'], max_expected_calls)
+
+    def test_knn_recursive(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vp_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0  # we s
+        nbors, dists = vp_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        print("debug")
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vp_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])
+
+    def test_knn_iterative(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vp_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0  # we s
+        nbors, dists = vp_knn_iterative(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+        print("debug")
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vp_knn_iterative(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q,   q-1, q-2, q-3, q-4,
+                                  q-5, q-6, q-7, q-8, q-9])
+
+    def test_knn_iterative_heapq(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vp_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0
+        nbors, dists = vp_knn_iterative_heapq(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vp_knn_iterative_heapq(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q,   q-1, q-2, q-3, q-4,
+                                  q-5, q-6, q-7, q-8, q-9])
+
+
+class TestVpsTree (unittest.TestCase, TestVpBase):
+
+    P = 12
+
+    def test_make_tree(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        vps_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+        # Calls to distance function should be <= O(n*log(n))
+        max_expected_calls = len(S) * math.log(len(S), 2)
+        self.assertLessEqual(c['count'], max_expected_calls)
+
+    def test_knn_recursive(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vps_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0
+        nbors, dists = vps_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vps_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])
+
+    def test_knn_iterative_heapq(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vps_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0
+        nbors, dists = vps_knn_iterative_heapq(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vps_knn_iterative_heapq(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q,   q-1, q-2, q-3, q-4,
+                                  q-5, q-6, q-7, q-8, q-9])
+
+    def test_make_deduplicate(self):
+        # Make set with duplicate elements (two copies of each integer).
+        S = self._make_sequential_set() + self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+
+        # Build with duplicates enabled.
+        root = vps_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+        c['count'] = 0
+        q = 0
+        nbors, dists = vps_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 0, 1, 1, 2, 2, 3, 3, 4, 4])
+
+        # Build with deduplification.
+        root = vps_make_tree(S, dist_func, deduplicate=True,
+                             r_seed=self.RAND_SEED)
+        c['count'] = 0
+        q = 0
+        nbors, dists = vps_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+
+class TestVpsbTree (unittest.TestCase, TestVpBase):
+
+    P = 12
+
+    def test_make_tree(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+
+        root = vpsb_make_tree(S, dist_func, 2, r_seed=self.RAND_SEED)
+        # Calls to distance function should be <= O(n*(log(n)/log(2)))
+        max_expected_calls = len(S) * math.log(len(S), 2)
+        self.assertLessEqual(c['count'], max_expected_calls)
+        c['count'] = 0
+
+        root = vpsb_make_tree(S, dist_func, 3, r_seed=self.RAND_SEED)
+        # Calls to distance function should be <= O(n*(log(n)/log(3)))
+        max_expected_calls = len(S) * math.log(len(S), 3)
+        self.assertLessEqual(c['count'], max_expected_calls)
+        c['count'] = 0
+
+        root = vpsb_make_tree(S, dist_func, 9, r_seed=self.RAND_SEED)
+        # Calls to distance function should be <= O(n*(log(n)/log(9)))
+        # TODO: Adding a 10% fudge factor here because its clocking in at a
+        #       little over expected runtime and not sure why at the moment,
+        #       possible because the tree isn't cleanly balanced?
+        max_expected_calls = len(S) * math.log(len(S), 9) + (len(S) * 0.1)
+        self.assertLessEqual(c['count'], max_expected_calls)
+        c['count'] = 0
+
+    def test_make_deduplicate(self):
+        # Make set with duplicate elements (two copies of each integer).
+        S = self._make_sequential_set() + self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+
+        # Build with duplicates enabled.
+        root = vpsb_make_tree(S, dist_func, branching_factor=2,
+                              r_seed=self.RAND_SEED)
+        c['count'] = 0
+        q = 0
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 0, 1, 1, 2, 2, 3, 3, 4, 4])
+
+        # Build with deduplification.
+        root = vpsb_make_tree(S, dist_func, branching_factor=2,
+                              deduplicate=True, r_seed=self.RAND_SEED)
+        c['count'] = 0
+        q = 0
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # Build with deduplification, 3-branch.
+        root = vpsb_make_tree(S, dist_func, branching_factor=3,
+                              deduplicate=True, r_seed=self.RAND_SEED)
+        c['count'] = 0
+        q = 0
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    def test_knn_recursive_branching2(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vpsb_make_tree(S, dist_func, branching_factor=2,
+                              r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])
+
+    def test_knn_recursive_branching3(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vpsb_make_tree(S, dist_func, branching_factor=3,
+                              r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])
+
+    def test_knn_recursive_branching9(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        root = vpsb_make_tree(S, dist_func, branching_factor=9,
+                              r_seed=self.RAND_SEED)
+
+        # With a query of "0" we should see sequence from S from low to high.
+        c['count'] = 0  # reset dist func counter
+        q = 0
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # With query of "len(S)", we should see reverse sequence from S from
+        # high to low.
+        c['count'] = 0  # reset dist func counter
+        q = max(S)
+        nbors, dists = vpsb_knn_recursive(q, 10, root, dist_func)
+        self.assertSequenceEqual(nbors,
+                                 [q, q - 1, q - 2, q - 3, q - 4,
+                                  q - 5, q - 6, q - 7, q - 8, q - 9])

--- a/python/smqtk/tests/utils/test_vptree.py
+++ b/python/smqtk/tests/utils/test_vptree.py
@@ -52,8 +52,11 @@ def assert_vptrees_equal(tree1, tree2):
             nose.tools.assert_is(tree1.mu, tree2.mu)
         else:
             numpy.testing.assert_almost_equal(tree1.mu, tree2.mu)
-        assert_vptrees_equal(tree1.left, tree2.left)
-        assert_vptrees_equal(tree1.right, tree2.right)
+        if tree1.children is None or tree2.children is None:
+            nose.tools.assert_is(tree1.children, tree2.children)
+        else:
+            for child1, child2 in zip(tree1.children, tree2.children):
+                assert_vptrees_equal(child1, child2)
 
 
 def assert_vpstrees_equal(tree1, tree2):
@@ -74,8 +77,11 @@ def assert_vpstrees_equal(tree1, tree2):
             nose.tools.assert_is(tree1.mu, tree2.mu)
         else:
             numpy.testing.assert_almost_equal(tree1.mu, tree2.mu)
-        assert_vpstrees_equal(tree1.left, tree2.left)
-        assert_vpstrees_equal(tree1.right, tree2.right)
+        if tree1.children is None or tree2.children is None:
+            nose.tools.assert_is(tree1.children, tree2.children)
+        else:
+            for child1, child2 in zip(tree1.children, tree2.children):
+                assert_vpstrees_equal(child1, child2)
 
 
 def assert_vpsbtrees_equal(tree1, tree2):

--- a/python/smqtk/tests/utils/test_vptree.py
+++ b/python/smqtk/tests/utils/test_vptree.py
@@ -6,6 +6,9 @@ import unittest
 
 from six.moves import range
 
+import nose.tools
+import numpy
+
 from smqtk.utils.vptree import *
 
 
@@ -19,6 +22,93 @@ def dist_func_counter(d):
     :type d: dict
     """
     d['count'] = d.get('count', 0) + 1
+
+
+def print_tree(tree, offset=0):
+    ret = "{} {}".format("|"*offset, tree)
+    if tree is not None:
+        ret = "\n".join((
+            ret,
+            print_tree(tree.left, offset=offset+1),
+            print_tree(tree.right, offset=offset+1)
+        ))
+    return ret
+
+
+def assert_vptrees_equal(tree1, tree2):
+    """
+    Assert two vp trees are equivalent
+    :param tree1: Root node of one tree
+    :type tree1: VpNode
+    :param tree2: Root node of other tree
+    :type tree2: VpNode
+    """
+    if tree1 is None or tree2 is None:
+        nose.tools.assert_is(tree1, tree2)
+    else:
+        nose.tools.assert_equal(tree1.p, tree2.p)
+        nose.tools.assert_equal(tree1.p, tree2.p)
+        if tree1.mu is None or tree2.mu is None:
+            nose.tools.assert_is(tree1.mu, tree2.mu)
+        else:
+            numpy.testing.assert_almost_equal(tree1.mu, tree2.mu)
+        assert_vptrees_equal(tree1.left, tree2.left)
+        assert_vptrees_equal(tree1.right, tree2.right)
+
+
+def assert_vpstrees_equal(tree1, tree2):
+    """
+    Assert two vps trees are equivalent
+    :param tree1: Root node of one tree
+    :type tree1: VpsNode
+    :param tree2: Root node of other tree
+    :type tree2: VpsNode
+    """
+    if tree1 is None or tree2 is None:
+        nose.tools.assert_is(tree1, tree2)
+    else:
+        nose.tools.assert_equal(tree1.p, tree2.p)
+        nose.tools.assert_equal(tree1.p, tree2.p)
+        nose.tools.assert_sequence_equal(tree1.bounds, tree2.bounds)
+        if tree1.mu is None or tree2.mu is None:
+            nose.tools.assert_is(tree1.mu, tree2.mu)
+        else:
+            numpy.testing.assert_almost_equal(tree1.mu, tree2.mu)
+        assert_vpstrees_equal(tree1.left, tree2.left)
+        assert_vpstrees_equal(tree1.right, tree2.right)
+
+
+def assert_vpsbtrees_equal(tree1, tree2):
+    """
+    Assert two vpsb trees are equivalent
+    :param tree1: Root node of one tree
+    :type tree1: VpsbNode
+    :param tree2: Root node of other tree
+    :type tree2: VpsbNode
+    """
+    if tree1 is None or tree2 is None:
+        nose.tools.assert_is(tree1, tree2)
+    else:
+        nose.tools.assert_equal(tree1.p, tree2.p)
+        nose.tools.assert_equal(tree1.p, tree2.p)
+        nose.tools.assert_sequence_equal(tree1.bounds, tree2.bounds)
+        if tree1.mu is None or tree2.mu is None:
+            nose.tools.assert_is(tree1.mu, tree2.mu)
+        else:
+            for mu1, mu2 in zip(tree1.mu, tree2.mu):
+                if mu1 is None or mu2 is None:
+                    nose.tools.assert_is(mu1, mu2)
+                else:
+                    numpy.testing.assert_almost_equal(mu1, mu2)
+        if tree1.max_children is None or tree2.max_children is None:
+            nose.tools.assert_is(tree1.max_children, tree2.max_children)
+        else:
+            numpy.testing.assert_equal(tree1.max_children, tree2.max_children)
+        if tree1.children is None or tree2.children is None:
+            nose.tools.assert_is(tree1.children, tree2.children)
+        else:
+            for child1, child2 in zip(tree1.children, tree2.children):
+                assert_vpsbtrees_equal(child1, child2)
 
 
 class TestVpBase (object):
@@ -60,6 +150,20 @@ class TestVpTree (unittest.TestCase, TestVpBase):
         # Calls to distance function should be <= O(n*log(n))
         max_expected_calls = len(S) * math.log(len(S), 2)
         self.assertLessEqual(c['count'], max_expected_calls)
+
+    def test_array_conversion(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        vpt = vp_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+        vp_arrays = vpt.to_arrays()
+        vpt2 = VpNode.from_arrays(
+            vp_arrays['value_array'],
+            vp_arrays['mu_array'],
+            vp_arrays['nd_array'],
+        )
+        assert_vptrees_equal(vpt, vpt2)
+
 
     def test_knn_recursive(self):
         S = self._make_sequential_set()
@@ -139,6 +243,20 @@ class TestVpsTree (unittest.TestCase, TestVpBase):
         # Calls to distance function should be <= O(n*log(n))
         max_expected_calls = len(S) * math.log(len(S), 2)
         self.assertLessEqual(c['count'], max_expected_calls)
+
+    def test_array_conversion(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        vpt = vps_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+        vp_arrays = vpt.to_arrays()
+        vpt2 = VpsNode.from_arrays(
+            vp_arrays['value_array'],
+            vp_arrays['mu_array'],
+            vp_arrays['nd_array'],
+            vp_arrays['bounds_array'],
+        )
+        assert_vpstrees_equal(vpt, vpt2)
 
     def test_knn_recursive(self):
         S = self._make_sequential_set()
@@ -233,6 +351,20 @@ class TestVpsbTree (unittest.TestCase, TestVpBase):
         max_expected_calls = len(S) * math.log(len(S), 9) + (len(S) * 0.1)
         self.assertLessEqual(c['count'], max_expected_calls)
         c['count'] = 0
+
+    def test_array_conversion(self):
+        S = self._make_sequential_set()
+        c = {}
+        dist_func = self._make_dist_func(max(S), c)
+        vpt = vpsb_make_tree(S, dist_func, r_seed=self.RAND_SEED)
+        vp_arrays = vpt.to_arrays()
+        vpt2 = VpsbNode.from_arrays(
+            vp_arrays['value_array'],
+            vp_arrays['mu_array'],
+            vp_arrays['nd_array'],
+            vp_arrays['bounds_array'],
+        )
+        assert_vpsbtrees_equal(vpt, vpt2)
 
     def test_make_deduplicate(self):
         # Make set with duplicate elements (two copies of each integer).

--- a/python/smqtk/tests/utils/test_vptree.py
+++ b/python/smqtk/tests/utils/test_vptree.py
@@ -29,17 +29,6 @@ def dist_func_counter(d):
     d['count'] = d.get('count', 0) + 1
 
 
-def print_tree(tree, offset=0):
-    ret = "{} {}".format("|" * offset, tree)
-    if tree is not None:
-        ret = "\n".join((
-            ret,
-            print_tree(tree.left, offset=offset + 1),
-            print_tree(tree.right, offset=offset + 1)
-        ))
-    return ret
-
-
 def assert_vptrees_equal(tree1, tree2):
     """
     Assert two vp trees are equivalent

--- a/python/smqtk/utils/__init__.py
+++ b/python/smqtk/utils/__init__.py
@@ -11,6 +11,9 @@ import logging
 import operator as op
 
 
+INF = float("inf")
+
+
 class SmqtkObject (object):
     """
     Highest level object interface for classes defined in SMQTK.

--- a/python/smqtk/utils/bit_utils.py
+++ b/python/smqtk/utils/bit_utils.py
@@ -131,13 +131,10 @@ def bit_vector_to_int(v):
     :rtype: int
 
     """
-    if not hasattr(v, 'data') or v.dtype == numpy.dtype('object'):
-        c = 0L
-        for b in v:
-            c = (c * 2L) + int(b)
-        return c
-    else:
-        return _bit_vector_to_int_fast(v)
+    c = 0L
+    for b in v:
+        c = (c * 2L) + int(b)
+    return c
 
 
 def bit_vector_to_int_large(v):
@@ -184,7 +181,6 @@ def _int_to_bit_vector_fast(integer, bits=0):
     return numpy.frombuffer(brep, dtype='bool')
 
 
-@jit
 def int_to_bit_vector(integer, bits=0):
     """
     Transform integer into a bit vector, optionally of a specific length.

--- a/python/smqtk/utils/bit_utils.py
+++ b/python/smqtk/utils/bit_utils.py
@@ -105,9 +105,8 @@ def _bit_vector_to_int_fast(v):
     :rtype: int
     """
     pad = '\x00' * (v.dtype.itemsize - 1)
-    if (
-            v.dtype.byteorder == '<' or
-            (v.dtype.byteorder == '=' and sys.byteorder == 'little')):
+    if (v.dtype.byteorder == '<' or
+        (v.dtype.byteorder == '=' and sys.byteorder == 'little')):
         zero_str = '\x00{}'.format(pad)
         one_str = '\x01{}'.format(pad)
     else:

--- a/python/smqtk/utils/vptree/__init__.py
+++ b/python/smqtk/utils/vptree/__init__.py
@@ -1,0 +1,6 @@
+"""
+Pass-through all vp-tree utility functions.
+"""
+from .vp import *
+from .vps import *
+from .vpsb import *

--- a/python/smqtk/utils/vptree/vp.py
+++ b/python/smqtk/utils/vptree/vp.py
@@ -8,7 +8,7 @@ import random
 import numpy
 import six
 
-from kw_vptree import INF
+from smqtk.utils import INF
 
 
 __all__ = [

--- a/python/smqtk/utils/vptree/vp.py
+++ b/python/smqtk/utils/vptree/vp.py
@@ -1,0 +1,395 @@
+"""
+VP Tree implementation functions
+"""
+import collections
+import heapq
+import random
+
+import numpy
+import six
+
+from kw_vptree import INF
+
+
+__all__ = [
+    'VpNode',
+    'vp_make_tree',
+    'vp_knn_recursive',
+    'vp_knn_iterative',
+    'vp_knn_iterative_heapq',
+]
+
+
+class VpNode (object):
+
+    def __init__(self):
+        # node value
+        #: :type: object
+        self.p = None
+        # Median distance to children
+        #: :type: float
+        self.mu = None
+        # Number of nodes that can be found as descendants underneath this node,
+        # including immediate children.
+        #: :type: int | long
+        self.num_descendants = None
+
+        # to nodes within mu radius
+        #: :type: VpNode
+        self.left = None
+        # to nodes on/outside mu radius
+        #: :type: VpNode
+        self.right = None
+
+    def __repr__(self):
+        return "%s{p: %s, mu: %s, descendants: %d}" \
+               % (self.__class__.__name__, self.p, self.mu,
+                  self.num_descendants)
+
+    def is_leaf(self):
+        """
+        :return: If this node is a leaf in the tree.
+        :rtype: bool
+        """
+        return self.left is None and self.right is None
+
+
+def vp_make_tree(S, d, r_seed=None):
+    """
+    Create VP Tree, returning the root node.
+
+    Elements of S must be hashable for use with element de-duplication.
+
+    Side effect: Duplicate values in S are ignored such that only unique values
+        in S are stored.
+
+    :param S: metric space elements
+    :param d: distance function between two elements of S. This should yield
+        distances in the [0,1] range.
+    :param r_seed: random seed int
+
+    :return: Root node of the tree
+    :rtype: VpNode
+
+    """
+    if r_seed is not None:
+        random.seed(r_seed)
+    # TODO: Convert S to a numpy object array to leverage array view slicing.
+    return _vp_make_tree_inner(S, d)
+
+
+def _vp_make_tree_inner(S, d):
+    """
+    Side effect: Duplicate values in S are ignored such that only unique values
+        in S are stored.
+
+    :param S: metric space elements
+    :param d: distance function between two elements of S. This should yield
+        distances in the [0,1] range.
+
+    :return: Root node of the tree
+    :rtype: VpNode
+
+    """
+    if S is None or len(S) == 0:
+        return None
+
+    # TODO: make local sequence of S in case S is an iterable.
+
+    n = VpNode()
+
+    # Only one item left, this is a leaf node.
+    if len(S) == 1:
+        n.p = S[0]
+        n.mu = d(n.p, n.p)  # or 0 if assuming 0 distance to self.
+        n.num_descendants = 0
+        return n
+
+    n.p = _vp_select_vantage_random(S)
+    # n.p = vp_select_vantage_probabilistic(S, d, r)
+
+    S_d = dict((s_, d(n.p, s_)) for s_ in S)
+    del S_d[n.p]  # remove vantage point from children to consider.
+    n.mu = numpy.median(list(six.itervalues(S_d)))
+    n.num_descendants = len(S_d)
+
+    L = []
+    R = []
+    for s, dist in six.iteritems(S_d):
+        # The vantage point was removed from this mapping earlier, so do not
+        # have to worry about that.
+        if dist < n.mu:
+            L.append(s)
+        else:
+            R.append(s)
+    n.left = _vp_make_tree_inner(L, d)
+    n.right = _vp_make_tree_inner(R, d)
+
+    return n
+
+
+def _vp_select_vantage_random(S):
+    """
+    Select random point from ``S`` to be the vantage point.
+    :param S: Set of elements.
+    :type S: collections.Sequence
+
+    :return: Randomly selected element within ``S``.
+    :rtype: object
+
+    """
+    return S[random.randint(0, len(S)-1)]
+
+
+def vp_select_vantage_probabilistic(S, d, r):
+    """
+    Select a vantage point element.
+
+    :param S: metric space elements
+    :type S: collection.Sequence[object]
+
+    :param d: distance function between two elements of S. This should yield
+        distances in the [0,1] range.
+    :type d: (object, object) -> float
+
+    :param r: random subsample percentage in the [0, 1] range.
+    :type r: float
+
+    :return: Vantage point value.
+    :rtype: object
+
+    """
+    # noinspection PyDefaultArgument
+    def get_d(a, b, cache={}):
+        # faster than: i, j = (min(a, b), max(a, b))
+        i, j = ((a < b) and (a, b)) or (b, a)
+        if not (i in cache and j in cache[i]):
+            cache.setdefault(i, {})[j] = d(i, j)
+        return cache[i][j]
+
+    # Pick a sample of S as possible vantage points.
+    P = random.sample(S, int(max(round(len(S) * r), 1)))
+    best_spread = None
+    best_p = None
+    for p in P:
+        # Pick a sample of S to test vantage point position.
+        D = random.sample(S, int(max(round(len(S) * r), 1)))
+        pD_dists = numpy.array([get_d(p, di) for di in D])
+        mu = numpy.mean(pD_dists)
+        spread = numpy.std(pD_dists - mu)
+        if best_spread is None or spread > best_spread:
+            best_spread = spread
+            best_p = p
+    return best_p
+
+
+def vp_knn_recursive(q, k, root, d_func):
+    """
+    Fine ``k`` nearest neighbors in tree with starting at ``root``.
+
+    :param q: Query value.
+    :type q: object
+
+    :param k: Number of neighbors to return.
+    :type k: int
+
+    :param root: Root node of VP tree. Must have been constructed with
+        ``vp_make_tree`` function.
+    :type root: VpNode
+
+    :param d_func: Distance metric function, which should return a value in the
+        [0, 1] range.
+    :type d_func: (object, object) -> float
+
+    :return: Parallel lists of near values and distances of those values from
+        the query node.
+    :rtype: (tuple[object], tuple[float])
+
+    """
+    def q_dist(n):
+        """
+        :param n: Node value
+        :type n: object
+        :return: Metric distance to query value
+        :rtype: float
+        """
+        return d_func(q, n)
+
+    # TODO: Encode into a class.
+    state = {
+        'k': k,
+        'q_distance': q_dist,
+        # "Max"" heap of neighbors. Python heapq always builds min-heaps, so we
+        # store (-dist, node) elements. Most distance neighbor will always be at
+        # top of heap due to distance negation.
+        'neighbors': [],
+        # Initial search radius. Whole tree considered, so tau is infinite to
+        # start.
+        'tau': INF,
+    }
+
+    # Start with the root node to search.
+    _vp_knn_recursive_inner(state, root)
+
+    # Unpack neighbor heap for return
+    dists, neighbors = zip(*sorted(map(lambda dn: (-dn[0], dn[1]),
+                                       state['neighbors'])))
+    return neighbors, dists
+
+
+def _vp_knn_recursive_inner(state, n):
+    """
+    Inner recursive search function. Returns nothing but updates the state as
+    appropriate.
+
+    :param state: Search state dictionary
+    :type state: dict
+    :param n: Tree node to consider.
+    :type n: VpNode
+
+    """
+    # Distance value from the current node's value to the query value.
+    d = state['q_distance'](n.p)
+
+    # locally record reference to mutable heap container in the state.
+    neighbors_heap = state['neighbors']
+
+    if len(state['neighbors']) < state['k']:
+        heapq.heappush(neighbors_heap, (-d, n.p))
+    elif d <= state['tau']:
+        # Add current node as the k+1'th element to heap and remove the then
+        # most distant candidate.
+        heapq.heappushpop(neighbors_heap, (-d, n.p))
+        # Update tau to the distance of the new most distance neighbor, which
+        # should be the top of the heap.
+        state['tau'] = -neighbors_heap[0][0]
+
+    # Stop if n is a leaf
+    if n.is_leaf():
+        return
+
+    if d < n.mu:
+        # Should at least check left child, optionally right if distance
+        # radius overlaps right region.
+        if n.left:  # d < n.mu + tau
+            _vp_knn_recursive_inner(state, n.left)
+        if n.right and d >= n.mu - state['tau']:
+            _vp_knn_recursive_inner(state, n.right)
+    else:
+        # Should at least check right child, optionally left if distance
+        # radius overlaps left region.
+        if n.right:  # d >= n.mu - tau
+            _vp_knn_recursive_inner(state, n.right)
+        if n.left and d < n.mu + state['tau']:
+            _vp_knn_recursive_inner(state, n.left)
+
+
+def vp_knn_iterative(q, k, root, distance):
+    """
+    Nearest neighbors only search from a query value ``q``.
+    """
+    # max-Heap of near neighbors
+    #   - python heapq does min-heap, so negating distances in heap
+    neighbors = []
+    tau = float('inf')
+    #: :type: collections.deque[VpNode]
+    to_search = collections.deque()
+    to_search.append(root)
+
+    while to_search:
+        n = to_search.popleft()
+        d = distance(q, n.p)
+
+        if len(neighbors) < k:
+            heapq.heappush(neighbors, [-d, n.p])
+        elif d <= tau:
+            # Add a k+1'th element to heap and remove the most distant
+            # candidate.
+            heapq.heappush(neighbors, [-d, n.p])
+            heapq.heappop(neighbors)
+            # Set tau to the distance of the new most distance neighbor
+            tau = -neighbors[0][0]
+
+        # shortcut if n is a leaf
+        if n.is_leaf():
+            continue
+
+        if d < n.mu:
+            # Should at least check left child, optionally right if distance
+            # radius overlaps right region.
+            if n.left:  # d < n.mu + tau
+                to_search.append(n.left)
+            if n.right and d >= n.mu - tau:
+                to_search.append(n.right)
+        else:
+            # Should at least check right child, optionally left if distance
+            # radius overlaps left region.
+            if n.right:  # d >= n.mu - tau
+                to_search.append(n.right)
+            if n.left and d < n.mu + tau:
+                to_search.append(n.left)
+
+    # Need to negate the negated distances for return
+    for n in neighbors:
+        n[0] = -n[0]
+    dists, neighbors = zip(*sorted(neighbors))
+    return neighbors, dists
+
+
+def vp_knn_iterative_heapq(q, k, root, distance):
+    """
+    Nearest neighbors only search from a query value ``q``.
+
+    This is the slowest of the three versions due to the overhead of the
+    ``to_search`` also being a heap.
+    """
+    # max-Heap of near neighbors
+    #   - python heapq does min-heap, so negating distances in heap
+    neighbors = []
+    tau = INF
+
+    # Min-heap of vantage point candidates
+    to_search = []
+
+    def to_search_push(n_):
+        heapq.heappush(to_search, (distance(q, n_.p), n_))
+
+    to_search_push(root)
+
+    while to_search:
+        d, n = heapq.heappop(to_search)
+
+        if len(neighbors) < k:
+            heapq.heappush(neighbors, [-d, n.p])
+        elif d <= tau:
+            # Add a k+1'th element to heap and remove the most distant
+            # candidate.
+            heapq.heappush(neighbors, [-d, n.p])
+            heapq.heappop(neighbors)
+            # Set tau to the distance of the new most distance neighbor
+            tau = -neighbors[0][0]
+
+        # shortcut if n is a leaf
+        if n.is_leaf():
+            continue
+
+        if d < n.mu:
+            # Should at least check left child, optionally right if distance
+            # radius overlaps right region.
+            if n.left:  # d < n.mu + tau
+                to_search_push(n.left)
+            if n.right and d >= n.mu - tau:
+                to_search_push(n.right)
+        else:
+            # Should at least check right child, optionally left if distance
+            # radius overlaps left region.
+            if n.right:  # d >= n.mu - tau
+                to_search_push(n.right)
+            if n.left and d < n.mu + tau:
+                to_search_push(n.left)
+
+    # Need to negate the negated distances for return
+    for n in neighbors:
+        n[0] = -n[0]
+    dists, neighbors = zip(*sorted(neighbors))
+    return neighbors, dists

--- a/python/smqtk/utils/vptree/vp.py
+++ b/python/smqtk/utils/vptree/vp.py
@@ -29,8 +29,8 @@ class VpNode (object):
         # Median distance to children
         #: :type: float
         self.mu = None
-        # Number of nodes that can be found as descendants underneath this node,
-        # including immediate children.
+        # Number of nodes that can be found as descendants underneath this
+        # node, including immediate children.
         #: :type: int | long
         self.num_descendants = None
 
@@ -138,7 +138,7 @@ def _vp_select_vantage_random(S):
     :rtype: object
 
     """
-    return S[random.randint(0, len(S)-1)]
+    return S[random.randint(0, len(S) - 1)]
 
 
 def vp_select_vantage_probabilistic(S, d, r):
@@ -220,8 +220,8 @@ def vp_knn_recursive(q, k, root, d_func):
         'k': k,
         'q_distance': q_dist,
         # "Max"" heap of neighbors. Python heapq always builds min-heaps, so we
-        # store (-dist, node) elements. Most distance neighbor will always be at
-        # top of heap due to distance negation.
+        # store (-dist, node) elements. Most distance neighbor will always be
+        # at top of heap due to distance negation.
         'neighbors': [],
         # Initial search radius. Whole tree considered, so tau is infinite to
         # start.

--- a/python/smqtk/utils/vptree/vps.py
+++ b/python/smqtk/utils/vptree/vps.py
@@ -6,8 +6,8 @@ import random
 
 import numpy
 
-from kw_vptree import INF
-from kw_vptree.vp import VpNode, _vp_select_vantage_random
+from smqtk.utils import INF
+from smqtk.utils.vptree.vp import VpNode, _vp_select_vantage_random
 
 
 __all__ = [

--- a/python/smqtk/utils/vptree/vps.py
+++ b/python/smqtk/utils/vptree/vps.py
@@ -104,8 +104,8 @@ def _vps_make_tree_inner(item_list, d):
 
     # Determine bounds of this node's children with respect to item distances
     # from the parent (current last distance in ``item.hist`` list).
-    # - All item histories at this point should be of the same length, so we can
-    #   pick the first one to determine level.
+    # - All item histories at this point should be of the same length, so we
+    #   can pick the first one to determine level.
     n.bounds = []
     node_level = len(item_list[0].hist)
     for hist_i in range(node_level):
@@ -168,8 +168,8 @@ def vps_knn_recursive(q, k, root, dist_func):
         'k': k,
         'q_distance': q_dist,
         # "Max" heap of neighbors. Python heapq always builds min-heaps, so we
-        # store (-dist, node) elements. Most distance neighbor will always be at
-        # top of heap due to distance negation.
+        # store (-dist, node) elements. Most distance neighbor will always be
+        # at top of heap due to distance negation.
         'neighbors': [],
         # Initial search radius. Whole tree considered, so tau is infinite to
         # start.
@@ -239,7 +239,7 @@ def vps_knn_iterative_heapq(q, k, root, dist_func):
     ``root`` must be the result of calling ``vps_make_tree`` in order for nodes
     to have the correct properties for this flavor of search.
 
-    This implementation uses a heap to rank the next branch to search down by 
+    This implementation uses a heap to rank the next branch to search down by
     distance from the query.
 
     :param q: Query value.
@@ -251,8 +251,8 @@ def vps_knn_iterative_heapq(q, k, root, dist_func):
     :param root: Root node of the VPS tree.
     :type root: VpsNode
 
-    :param dist_func: Metric distance function that returns a floating point 
-        value in the [0, 1] range. This must be the same function used in the 
+    :param dist_func: Metric distance function that returns a floating point
+        value in the [0, 1] range. This must be the same function used in the
         creation of the VPS tree.
     :type dist_func: (object, object) -> float
 

--- a/python/smqtk/utils/vptree/vps.py
+++ b/python/smqtk/utils/vptree/vps.py
@@ -1,0 +1,310 @@
+"""
+VP^s implementation of the VP Tree structure.
+"""
+import heapq
+import random
+
+import numpy
+
+from kw_vptree import INF
+from kw_vptree.vp import VpNode, _vp_select_vantage_random
+
+
+__all__ = [
+    'VpsNode',
+    'vps_make_tree',
+    'vps_knn_recursive',
+    'vps_knn_iterative_heapq',
+]
+
+
+class VpsNode (VpNode):
+    """
+    Node structure used in a VPS tree.
+    """
+
+    def __init__(self):
+        super(VpsNode, self).__init__()
+
+        #
+        # For VP-S implementation
+        #
+        # Tuple of tuples describing the bounds of this and child elements with
+        # respect to ancestor nodes. Index 0 represents the root node, and
+        # subsequent indices refer to subsequent ancestor nodes.
+        # - bounds format: [(min, max), ...]
+        #: :type: list[(float, float)]
+        self.bounds = None
+
+        # Tree level of this node could be saved during VPS construction by
+        # observing how many ancestor distances a vantage point records upon
+        # node construction.
+
+
+class VpsItem (object):
+    """
+    Item structure used in the construction of a VPS tree.
+    """
+
+    def __init__(self, id_):
+        self.id = id_
+        self.hist = []
+
+
+def vps_make_tree(S, d, deduplicate=False, r_seed=None):
+    """
+    :param S: Metric space elements.
+    :type S: collections.Iterable[object]
+
+    :param d: Metric distance function: (a, b) -> [0, 1]
+    :type d: (object, object) -> float
+
+    :param deduplicate: Whether or not to deduplicate elements in ``S`` before
+        creating the tree (don't create representative VpsItem for that
+        element). Setting this to true requires that elements in ``S`` be
+        hashable in order to use them in a set.
+    :type deduplicate: bool
+
+    :return: Root node of VPS tree.
+    :rtype: VpsNode
+
+    """
+    if r_seed is not None:
+        random.seed(r_seed)
+    item_list = []
+    # Set of unique elements in S in order to deduplicate input values.
+    dedup_set = set()
+    for s in S:
+        if deduplicate:
+            if s in dedup_set:
+                continue
+            else:
+                dedup_set.add(s)
+        i = VpsItem(s)
+        item_list.append(i)
+    return _vps_make_tree_inner(item_list, d)
+
+
+def _vps_make_tree_inner(item_list, d):
+    """
+    :param item_list: "item" list.
+    :type item_list: list[VpsItem]
+
+    :param d: Metric distance function: (a, b) -> [0, 1]
+    :type d: (object, object) -> float
+
+    :return: Root node for this sub-tree.
+    :rtype: VpsNode
+
+    """
+    if item_list is None or len(item_list) == 0:
+        return None
+
+    n = VpsNode()
+
+    # Determine bounds of this node's children with respect to item distances
+    # from the parent (current last distance in ``item.hist`` list).
+    # - All item histories at this point should be of the same length, so we can
+    #   pick the first one to determine level.
+    n.bounds = []
+    node_level = len(item_list[0].hist)
+    for hist_i in range(node_level):
+        dist_i = map(lambda i_: i_.hist[hist_i], item_list)
+        n.bounds.append((min(dist_i), max(dist_i)))
+
+    # One item in list, thus this is a leaf node.
+    if len(item_list) == 1:
+        i = item_list[0]
+        n.p = i.id
+        n.num_descendants = 0
+        return n
+
+    #: :type: VpsItem
+    vp_i = _vp_select_vantage_random(item_list)
+    del item_list[item_list.index(vp_i)]
+    n.p = vp_i.id
+
+    # Collect and retain child element distances to the current vantage point.
+    p_dists = []  # parallel to current ``item_list``
+    for i in item_list:
+        di = d(n.p, i.id)
+        i.hist.append(di)
+        p_dists.append(di)
+
+    n.mu = numpy.median(p_dists)
+    n.num_descendants = len(p_dists)
+
+    # Items for left and right partitions.
+    L = []
+    R = []
+    for i in item_list:
+        if i.hist[-1] < n.mu:
+            L.append(i)
+        else:
+            R.append(i)
+    n.left = _vps_make_tree_inner(L, d)
+    n.right = _vps_make_tree_inner(R, d)
+
+    return n
+
+
+def _vps_check_in_bounds(n, dist, tau):
+    # Check if the distance +- tau overlaps `n`s lowest-level bounds.
+    return n and ((n.bounds[-1][0] - tau) <= dist <= (n.bounds[-1][1] + tau))
+
+
+def vps_knn_recursive(q, k, root, dist_func):
+    def q_dist(n):
+        """
+        :param n: Node value
+        :type n: object
+        :return: Metric distance to query value
+        :rtype: float
+        """
+        return dist_func(q, n)
+
+    # TODO: Encode into a class.
+    state = {
+        'k': k,
+        'q_distance': q_dist,
+        # "Max" heap of neighbors. Python heapq always builds min-heaps, so we
+        # store (-dist, node) elements. Most distance neighbor will always be at
+        # top of heap due to distance negation.
+        'neighbors': [],
+        # Initial search radius. Whole tree considered, so tau is infinite to
+        # start.
+        'tau': INF,
+    }
+
+    # Start with the root node to search.
+    _vps_knn_recursive_inner(state, root)
+
+    # Unpack neighbor heap for return
+    dists, neighbors = zip(*sorted(map(lambda dn: (-dn[0], dn[1]),
+                                       state['neighbors'])))
+    return neighbors, dists
+
+
+def _vps_knn_recursive_inner(state, n):
+    """
+    Inner recursive search function for searching a VPS tree. Returns nothing
+    but updates the state as appropriate.
+
+    :param state: Search state dictionary.
+    :type state: dict
+    :param n: Tree node to consider.
+    :type n: VpsNode
+    """
+    # Distance of query point from current node.
+    d = state['q_distance'](n.p)
+
+    # locally record reference to mutable heap container in the state.
+    neighbors_heap = state['neighbors']
+
+    if len(neighbors_heap) < state['k']:
+        heapq.heappush(neighbors_heap, (-d, n.p))
+    elif d <= state['tau']:
+        # Add a k+1'th element to heap and remove the most distant candidate.
+        heapq.heappushpop(neighbors_heap, (-d, n.p))
+        # Set tau to the distance of the new most distance neighbor
+        state['tau'] = -neighbors_heap[0][0]
+
+    # Stop if n is a leaf
+    if n.is_leaf():
+        return
+
+    # Descend into child nodes whose bounds potentially overlap the current tau
+    # radius.
+    if d < n.mu:
+        # q inside mu radius, more likely intersects inner shell, but may
+        # intersect outer shell.
+        if _vps_check_in_bounds(n.left, d, state['tau']):
+            _vps_knn_recursive_inner(state, n.left)
+        if _vps_check_in_bounds(n.right, d, state['tau']):
+            _vps_knn_recursive_inner(state, n.right)
+    else:
+        # q on/outside mu radius, more likely intersects outer shell, but may
+        # intersect inner shell.
+        if _vps_check_in_bounds(n.right, d, state['tau']):
+            _vps_knn_recursive_inner(state, n.right)
+        if _vps_check_in_bounds(n.left, d, state['tau']):
+            _vps_knn_recursive_inner(state, n.left)
+
+
+def vps_knn_iterative_heapq(q, k, root, dist_func):
+    """
+    Get the ``k`` nearest neighbors to the query value ``q`` given the ``root``
+    node of a VPS tree.
+
+    ``root`` must be the result of calling ``vps_make_tree`` in order for nodes
+    to have the correct properties for this flavor of search.
+
+    This implementation uses a heap to rank the next branch to search down by 
+    distance from the query.
+
+    :param q: Query value.
+    :type q: object
+
+    :param k: Number of nearest neighbors to return.
+    :type k: int
+
+    :param root: Root node of the VPS tree.
+    :type root: VpsNode
+
+    :param dist_func: Metric distance function that returns a floating point 
+        value in the [0, 1] range. This must be the same function used in the 
+        creation of the VPS tree.
+    :type dist_func: (object, object) -> float
+
+    :return: Two parallel list of the nearest neighbors values and their
+        metric distances from the query, in order of increasing distance.
+    :rtype: (list[object], list[float])
+
+    """
+    # max-Heap of near neighbors
+    #   - python heapq does min-heap, so negating distances in heap
+    neighbors = []
+    tau = INF
+
+    # Min-heap of vantage point candidates
+    # - Heap elements are of the format: (float, VpsNode)
+    to_search = []
+
+    def to_search_push(n):
+        """ Push a VpsNode onto the to-search heap. """
+        heapq.heappush(to_search, (dist_func(q, n.p), n))
+
+    to_search_push(root)
+
+    while to_search:
+        #: :type: (float, VpsNode)
+        d, n = heapq.heappop(to_search)
+        # ``d`` is the distance between ``q`` and ``n.p``
+
+        if len(neighbors) < k:
+            heapq.heappush(neighbors, [-d, n.p])
+        elif d <= tau:
+            # Add a k+1'th element to heap and remove the most distant
+            # candidate.
+            heapq.heappush(neighbors, [-d, n.p])
+            heapq.heappop(neighbors)
+            # Set tau to the distance of the new most distance neighbor
+            tau = -neighbors[0][0]
+
+        # shortcut if n is a leaf
+        if n.is_leaf():
+            continue
+
+        # Add child nodes whose bounds potentially overlap the current tau
+        # search radius
+        # TODO: Check multiple children when there are more than two.
+        if _vps_check_in_bounds(n.left, d, tau):
+            to_search_push(n.left)
+        if _vps_check_in_bounds(n.right, d, tau):
+            to_search_push(n.right)
+
+    # Need to negate the distances stored in list for return.
+    for n in neighbors:
+        n[0] = -n[0]
+    dists, neighbors = zip(*sorted(neighbors))
+    return neighbors, dists

--- a/python/smqtk/utils/vptree/vps.py
+++ b/python/smqtk/utils/vptree/vps.py
@@ -40,6 +40,118 @@ class VpsNode (VpNode):
         # observing how many ancestor distances a vantage point records upon
         # node construction.
 
+    def to_arrays(
+            self, value_array=None, mu_array=None, nd_array=None,
+            bounds_array=None):
+        """
+        Store data from this VP tree as numpy arrays for use in serialization.
+
+        The returned dictionary is suitable to be passed as the kwds argument
+        to numpy.savez.
+
+        :param value_array: An array to be filled with the node values of this
+            and child nodes arranged as a binary tree.
+        :type value_array: numpy.ndarray
+        :param mu_array: An array to be filled with the mu values of this
+            and child nodes arranged as a binary tree.
+        :type mu_array: numpy.ndarray[float]
+        :param nd_array: An array to be filled with the number of descendants
+            in each branch of this node.
+        :type nd_array: numpy.ndarray[numpy.ndarray[float]]
+        :param bounds_array: An array to be filled with the bounds of each node
+            in the tree.
+        :type bounds_array: numpy.ndarray[object]
+        :return: Dictionary with arrays as values and label strings as keys.
+        :rtype: dict[str, numpy.ndarray]
+        """
+        max_children = getattr(self, "max_children", 2)
+        children = getattr(self, "children", (self.left, self.right))
+        if value_array is None:
+            value_array = numpy.zeros(
+                self.num_descendants + 1, dtype=numpy.dtype(type(self.p))
+            )
+        if mu_array is None:
+            mu_array = numpy.zeros(self.num_descendants + 1, dtype='float')
+        if nd_array is None:
+            nd_array = numpy.zeros(
+                (self.num_descendants + 1, max_children), dtype='int')
+        if bounds_array is None:
+            bounds_array = numpy.zeros(self.num_descendants + 1, dtype='object')
+
+        if not len(value_array):
+            return
+
+        value_array[0] = self.p
+        mu_array[0] = self.mu
+        bounds_array[0] = self.bounds
+
+        begin_index = 1
+        end_index = 1
+        for i, child in enumerate(children):
+            if child is not None:
+                nd_array[0][i] = child.num_descendants + 1
+                begin_index = end_index
+                end_index += nd_array[0][i]
+                child.to_arrays(
+                    value_array=value_array[begin_index:end_index],
+                    mu_array=mu_array[begin_index:end_index],
+                    nd_array=nd_array[begin_index:end_index],
+                    bounds_array=bounds_array[begin_index:end_index],
+                )
+
+        return {
+            "value_array": value_array, "mu_array": mu_array,
+            "nd_array": nd_array, "bounds_array": bounds_array
+        }
+
+    @classmethod
+    def from_arrays(cls, value_array, mu_array, nd_array, bounds_array):
+        """
+        Construct VPS tree from arrays structured as binary trees.
+
+        This method is useful for reconstructing VP trees from serialized data.
+
+        :param value_array: An array with the node values of this and child
+            nodes arranged as a binary tree.
+        :type value_array: numpy.ndarray
+        :param mu_array: An array with the mu values of this and child nodes
+            arranged as a binary tree.
+        :type mu_array: numpy.ndarray[float]
+        :param nd_array: An array with the number of left and right descendants
+            of each node in tree.
+        :type nd_array: numpy.ndarray[float, float]
+        :param bounds_array: An array with the bounds of each node in the tree.
+        :type bounds_array: numpy.ndarray[object]
+        :return: Reconstructed VPS tree.
+        :rtype: VpsNode
+        """
+        if not len(value_array):
+            return None
+        new_node = cls()
+        new_node.p = value_array[0]
+        new_node.mu = mu_array[0]
+        if numpy.isnan(new_node.mu):
+            new_node.mu = None
+        new_node.num_descendants = numpy.sum(nd_array[0])
+        new_node.bounds = bounds_array[0]
+
+        children = []
+        begin_index = 1
+        end_index = 1
+        for nd in nd_array[0]:
+            begin_index = end_index
+            end_index += nd
+            children.append(
+                cls.from_arrays(
+                    value_array[begin_index:end_index],
+                    mu_array[begin_index:end_index],
+                    nd_array[begin_index:end_index],
+                    bounds_array[begin_index:end_index]
+                )
+            )
+        new_node.left, new_node.right = children
+        return new_node
+
 
 class VpsItem (object):
     """
@@ -131,8 +243,9 @@ def _vps_make_tree_inner(item_list, d):
         i.hist.append(di)
         p_dists.append(di)
 
-    n.mu = numpy.median(p_dists)
     n.num_descendants = len(p_dists)
+    if n.num_descendants:
+        n.mu = numpy.median(p_dists)
 
     # Items for left and right partitions.
     L = []

--- a/python/smqtk/utils/vptree/vps.py
+++ b/python/smqtk/utils/vptree/vps.py
@@ -403,11 +403,9 @@ def vps_knn_iterative_heapq(q, k, root, dist_func):
 
         # Add child nodes whose bounds potentially overlap the current tau
         # search radius
-        # TODO: Check multiple children when there are more than two.
-        if _vps_check_in_bounds(n.children[0], d, tau):
-            to_search_push(n.children[0])
-        if _vps_check_in_bounds(n.children[1], d, tau):
-            to_search_push(n.children[1])
+        for child in n.children:
+            if _vps_check_in_bounds(child, d, tau):
+                to_search_push(child)
 
     # Need to negate the distances stored in list for return.
     for n in neighbors:

--- a/python/smqtk/utils/vptree/vpsb.py
+++ b/python/smqtk/utils/vptree/vpsb.py
@@ -74,7 +74,6 @@ class VpsbNode (VpsNode):
         :rtype: dict[str, numpy.ndarray]
         """
         max_children = getattr(self, "max_children", 2)
-        children = getattr(self, "children", (self.left, self.right))
         if value_array is None:
             value_array = numpy.zeros(
                 self.num_descendants + 1, dtype=numpy.dtype(type(self.p))
@@ -95,10 +94,10 @@ class VpsbNode (VpsNode):
         mu_array[0] = self.mu
         bounds_array[0] = self.bounds
 
-        if children is not None:
+        if self.children is not None:
             begin_index = 1
             end_index = 1
-            for i, child in enumerate(children):
+            for i, child in enumerate(self.children):
                 if child is not None:
                     nd_array[0][i] = child.num_descendants + 1
                     begin_index = end_index

--- a/python/smqtk/utils/vptree/vpsb.py
+++ b/python/smqtk/utils/vptree/vpsb.py
@@ -1,0 +1,318 @@
+"""
+VP^sb implementation.
+
+This implementation adds a branching factor to tree construction and search.
+This is different than the original author's description in that each node has
+multiple children instead of only the leaf nodes having multiple data elements.
+"""
+import heapq
+import itertools
+import random
+
+import numpy
+import scipy.stats
+from six.moves import range
+
+from kw_vptree import INF
+from kw_vptree.vp import _vp_select_vantage_random
+from kw_vptree.vps import VpsNode, VpsItem, _vps_check_in_bounds
+
+
+__all__ = [
+    'VpsbNode',
+    'vpsb_make_tree',
+    'vpsb_knn_recursive',
+]
+
+
+class VpsbNode (VpsNode):
+    """
+    A VPSB node differs from previous node classes in that ``mu`` is a tuple of
+    distances corresponding to the number of children that node has
+    """
+
+    def __init__(self):
+        super(VpsbNode, self).__init__()
+
+        # Maximum number of children this node may have.
+        #: :type: None | int
+        self.max_children = None
+
+        # Tuple of child nodes to this node.
+        #: :type: None | tuple
+        self.children = None
+
+    def is_leaf(self):
+        """
+        :return: If this node has no children.
+        :rtype: bool
+        """
+        return (self.children is None) or (len(self.children) == 0)
+
+
+def vpsb_make_tree(S, d, branching_factor=2, deduplicate=False, r_seed=None,
+                   mu_selection='partition'):
+    """
+    Create a VP^SB tree structure.
+
+    :param S: Metric space elements.
+    :type S: collections.Iterable[object]
+
+    :param d: Metric distance function: (a, b) -> [0, 1]
+    :type d: (object, object) -> float
+
+    :param branching_factor: Maximum number of children per node.
+    :type branching_factor: int
+
+    :param deduplicate: Whether or not to deduplicate elements in ``S`` before
+        creating the tree (don't create representative VpsItem for that
+        element). Setting this to true requires that elements in ``S`` be
+        hashable in order to use them in a set.
+    :type deduplicate: bool
+
+    :param r_seed: Random number generator seed value.
+    :type r_seed: None | int
+
+    :param mu_selection: Mu value selection method. This must either be
+        'partition' or 'quantile'.
+        TODO: Explain the difference in methods.
+    :type mu_selection: str
+
+    :return: Root node of VPSB tree.
+    :rtype: VpsbNode
+
+    """
+    if r_seed is not None:
+        random.seed(r_seed)
+    if mu_selection not in {'partition', 'quantile'}:
+        raise ValueError("Unknown mu selection method: %s" % mu_selection)
+    item_list = []
+    # Set of unique elements in S in order to deduplicate input values.
+    dedup_set = set()
+    for s in S:
+        if deduplicate:
+            if s in dedup_set:
+                continue
+            else:
+                dedup_set.add(s)
+        i = VpsItem(s)
+        item_list.append(i)
+    del dedup_set
+    return _vpsb_make_tree_inner(item_list, d, branching_factor, mu_selection)
+
+
+def _vpsb_make_tree_inner(item_list, d, branching_factor, mu_selection):
+    """
+    :param item_list: "item" list.
+    :type item_list: list[VpsItem]
+
+    :param d: Metric distance function: (a, b) -> [0, 1]
+    :type d: (object, object) -> float
+
+    :param branching_factor: Max number of children for a node.
+    :type branching_factor: int
+
+    :param mu_selection: MU selection method name.
+    :type mu_selection: str
+
+    :return: Root node for this sub-tree.
+    :rtype: VpsbNode
+
+    """
+    if item_list is None or len(item_list) == 0:
+        return None
+
+    n = VpsbNode()
+    n.max_children = branching_factor
+
+    # Determine bounds of this node's children with respect to item distances
+    # from the parent (current last distance in ``item.hist`` list).
+    # - All item histories at this point should be of the same length, so we can
+    #   pick the first one to determine level.
+    n.bounds = []
+    node_level = len(item_list[0].hist)
+    for hist_i in range(node_level):
+        dist_i = map(lambda i_: i_.hist[hist_i], item_list)
+        n.bounds.append((min(dist_i), max(dist_i)))
+
+    # One item in list, thus this is a leaf node.
+    if len(item_list) == 1:
+        item = item_list[0]
+        n.p = item.id
+        n.num_descendants = 0
+        return n
+
+    #: :type: VpsItem
+    vp_i = _vp_select_vantage_random(item_list)
+    del item_list[item_list.index(vp_i)]
+    n.p = vp_i.id
+    n.num_descendants = len(item_list)
+
+    # Collect and retain child element distances to the current vantage point.
+    p_dists = []  # parallel to current ``item_list``
+    for item in item_list:
+        di = d(n.p, item.id)
+        item.hist.append(di)
+        p_dists.append(di)
+
+    # Select mu values separating child spaces.
+    children = min(branching_factor, len(item_list))
+
+    if mu_selection == 'partition':
+        # Selection (multi-median) method
+        # - quickly selects indices of kth smallest elements.
+        # - does not interpolate when median index is not integral, casts to
+        #   int.
+        interval = len(p_dists) / float(children)
+        mu_indices = map(lambda i: int(interval * i), range(1, children))
+        # Use a quick selection algorithm to find multiple "medians" in the
+        # array of distances without sorting the whole list. ``n.mu`` values
+        # will be in ascending order after ``numpy.partition``.
+        # TODO: Check proportion of indices to be selected to the size of the
+        #       array, simply sorting the array after proportion reaches a
+        #       threshold as selecting a large portion of the array is slower
+        #       than just sorting it.
+        n.mu = numpy.partition(p_dists, mu_indices)[mu_indices]
+    elif mu_selection == 'quantile':
+        # Quantile method -- uneven spaced bins, even bin counts.
+        # - basically more accurate version of selection method (getting similar
+        #   results experimentally)
+        # - quantile probability array is evenly spaced and given +1 in order to
+        #   make the appropriate number of bins.
+        quantile_probs = numpy.linspace(0, 1, children + 1)
+        p_dist_quantiles = scipy.stats.mstats.mquantiles(p_dists, quantile_probs)
+        # Mu values are the quantile values minus the min/max bounds.
+        n.mu = p_dist_quantiles[1:-1]
+    else:
+        raise ValueError("Invalid mu selection method: %s" % mu_selection)
+
+    # Sift items into bins based on mu values. Bins are in congruent order the
+    # the mu value list, which is in ascending order (smallest to largest), i.e.
+    # bin[0] are items closest to the vantage point and bin[-1] are items
+    # farthest away.
+    item_bins = tuple([] for _ in range(children))
+    dist_bins = [-INF] + list(n.mu) + [INF]
+    for item, bin_i in itertools.izip(item_list,
+                                      numpy.digitize(p_dists, dist_bins)):
+        # need the -1 because digitize's return is 1-index.
+        item_bins[bin_i-1].append(item)
+
+    # Recurse for each child bin in order.
+    n.children = map(lambda b: _vpsb_make_tree_inner(b, d, branching_factor,
+                                                     mu_selection),
+                     item_bins)
+
+    return n
+
+
+def vpsb_knn_recursive(q, k, root, dist_func):
+    """
+    K Nearest neighbor function for VP^sb tree.
+
+    :param q: Query value.
+    :type q: object
+
+    :param k: Number of neighbors to find.
+    :type k: int
+
+    :param root: Tree root node.
+    :type root: VpsbNode
+
+    :param dist_func: Distance metric function: (a, b) -> [0, 1]. Should be the
+        same function used when building the tree.
+    :type dist_func: (object, object) -> float
+
+    :return: Parallel lists of neighbor values and their distances from the
+        query value.
+    :rtype: object
+
+    """
+    def q_dist(n):
+        """
+        :param n: Node value
+        :type n: object
+        :return: Metric distance to query value
+        :rtype: float
+        """
+        return dist_func(q, n)
+
+    # TODO: Encode into a class.
+    state = {
+        'k': k,
+        'q_distance': q_dist,
+        # "Max" heap of neighbors. Python heapq always builds min-heaps, so we
+        # store (-dist, node) elements. Most distance neighbor will always be at
+        # top of heap due to distance negation.
+        'neighbors': [],
+        # Initial search radius. Whole tree considered, so tau is infinite to
+        # start.
+        'tau': INF,
+    }
+    # Start with the root node to search.
+    _vpsb_knn_recursive_inner(state, root)
+
+    # Unpack neighbor heap for return
+    dists, neighbors = zip(*sorted(map(lambda dn: (-dn[0], dn[1]),
+                                       state['neighbors'])))
+    return neighbors, dists
+
+
+def _vpsb_child_order_key(child, dist):
+    """
+    Generate the key value for a child node for potential recursive search 
+    order.
+    """
+    if child is None:
+        return INF, INF
+    else:
+        # distance bounds from immediate parent node.
+        c_bounds = child.bounds[-1]
+        return (
+            # If we're concretely in the bounds of the current child node
+            # True (1) should be less than failure value, because sorting.
+            int(c_bounds[0] <= dist <= c_bounds[1]) or 2,
+            min(abs(dist - c_bounds[0]), abs(dist - c_bounds[1])),
+        )
+
+
+def _vpsb_knn_recursive_inner(state, n):
+    """
+    Inner recursive search function for searching a VP^sb tree. Returns nothing
+    but updates the state as appropriate.
+
+    :param state: Search state dictionary.
+    :type state: dict
+
+    :param n: Tree node to consider.
+    :type n: VpsbNode
+
+    """
+    # Distance of query point from current node.
+    d = state['q_distance'](n.p)
+
+    # locally record reference to mutable heap container in the state.
+    neighbors_heap = state['neighbors']
+
+    if len(neighbors_heap) < state['k']:
+        heapq.heappush(neighbors_heap, (-d, n.p))
+    elif d <= state['tau']:
+        # Add a k+1'th element to heap and remove the most distant candidate.
+        heapq.heappushpop(neighbors_heap, (-d, n.p))
+        # Set tau to the distance of the new most distance neighbor
+        state['tau'] = -neighbors_heap[0][0]
+
+    # Stop if n is a leaf
+    if n.is_leaf():
+        return
+
+    # Order child nodes based on how close the query point is from that node's
+    # bounds range. This is equivalent to checking on what side of the mu
+    # boundary the query distance is.
+    # - child node should never be None-valued since only actual children are
+    #   stored during build.
+    # map(lambda c: _vpsb_check_bounds(c, d, state[]), n.children)
+    ordered_children = sorted(n.children,
+                              key=lambda c: _vpsb_child_order_key(c, d))
+    for node in ordered_children:
+        if _vps_check_in_bounds(node, d, state['tau']):
+            _vpsb_knn_recursive_inner(state, node)

--- a/python/smqtk/utils/vptree/vpsb.py
+++ b/python/smqtk/utils/vptree/vpsb.py
@@ -172,7 +172,10 @@ def _vpsb_make_tree_inner(item_list, d, branching_factor, mu_selection):
         #       array, simply sorting the array after proportion reaches a
         #       threshold as selecting a large portion of the array is slower
         #       than just sorting it.
-        n.mu = numpy.partition(p_dists, mu_indices)[mu_indices]
+        if not mu_indices:
+            n.mu = []
+        else:
+            n.mu = numpy.partition(p_dists, mu_indices)[mu_indices]
     elif mu_selection == 'quantile':
         # Quantile method -- uneven spaced bins, even bin counts.
         # - basically more accurate version of selection method (getting
@@ -187,7 +190,7 @@ def _vpsb_make_tree_inner(item_list, d, branching_factor, mu_selection):
     else:
         raise ValueError("Invalid mu selection method: %s" % mu_selection)
 
-    # Sift items into bins based on mu values. Bins are in congruent order the
+    # Sift items into bins based on mu values. Bins are in congruent order to
     # the mu value list, which is in ascending order (smallest to largest),
     # i.e. bin[0] are items closest to the vantage point and bin[-1] are items
     # farthest away.

--- a/python/smqtk/utils/vptree/vpsb.py
+++ b/python/smqtk/utils/vptree/vpsb.py
@@ -14,7 +14,7 @@ import scipy.stats
 from six.moves import range
 
 from smqtk.utils import INF
-from smqtk.utils.vptree.vp import _vp_select_vantage_random
+from smqtk.utils.vptree.vp import _vp_select_vantage_random, VpSearchState
 from smqtk.utils.vptree.vps import VpsNode, VpsItem, _vps_check_in_bounds
 
 
@@ -360,24 +360,13 @@ def vpsb_knn_recursive(q, k, root, dist_func):
         """
         return dist_func(q, n)
 
-    # TODO: Encode into a class.
-    state = {
-        'k': k,
-        'q_distance': q_dist,
-        # "Max" heap of neighbors. Python heapq always builds min-heaps, so we
-        # store (-dist, node) elements. Most distance neighbor will always be
-        # at top of heap due to distance negation.
-        'neighbors': [],
-        # Initial search radius. Whole tree considered, so tau is infinite to
-        # start.
-        'tau': INF,
-    }
+    state = VpSearchState(k, q_dist)
     # Start with the root node to search.
     _vpsb_knn_recursive_inner(state, root)
 
     # Unpack neighbor heap for return
     dists, neighbors = zip(*sorted(map(lambda dn: (-dn[0], dn[1]),
-                                       state['neighbors'])))
+                                       state.neighbors)))
     return neighbors, dists
 
 
@@ -404,26 +393,26 @@ def _vpsb_knn_recursive_inner(state, n):
     Inner recursive search function for searching a VP^sb tree. Returns nothing
     but updates the state as appropriate.
 
-    :param state: Search state dictionary.
-    :type state: dict
+    :param state: Search state
+    :type state: VpSearchState
 
     :param n: Tree node to consider.
     :type n: VpsbNode
 
     """
     # Distance of query point from current node.
-    d = state['q_distance'](n.p)
+    d = state.q_distance(n.p)
 
     # locally record reference to mutable heap container in the state.
-    neighbors_heap = state['neighbors']
+    neighbors_heap = state.neighbors
 
-    if len(neighbors_heap) < state['k']:
+    if len(neighbors_heap) < state.k:
         heapq.heappush(neighbors_heap, (-d, n.p))
-    elif d <= state['tau']:
+    elif d <= state.tau:
         # Add a k+1'th element to heap and remove the most distant candidate.
         heapq.heappushpop(neighbors_heap, (-d, n.p))
         # Set tau to the distance of the new most distance neighbor
-        state['tau'] = -neighbors_heap[0][0]
+        state.tau = -neighbors_heap[0][0]
 
     # Stop if n is a leaf
     if n.is_leaf():
@@ -438,5 +427,5 @@ def _vpsb_knn_recursive_inner(state, n):
     ordered_children = sorted(n.children,
                               key=lambda c: _vpsb_child_order_key(c, d))
     for node in ordered_children:
-        if _vps_check_in_bounds(node, d, state['tau']):
+        if _vps_check_in_bounds(node, d, state.tau):
             _vpsb_knn_recursive_inner(state, node)

--- a/python/smqtk/utils/vptree/vpsb.py
+++ b/python/smqtk/utils/vptree/vpsb.py
@@ -13,9 +13,9 @@ import numpy
 import scipy.stats
 from six.moves import range
 
-from kw_vptree import INF
-from kw_vptree.vp import _vp_select_vantage_random
-from kw_vptree.vps import VpsNode, VpsItem, _vps_check_in_bounds
+from smqtk.utils import INF
+from smqtk.utils.vptree.vp import _vp_select_vantage_random
+from smqtk.utils.vptree.vps import VpsNode, VpsItem, _vps_check_in_bounds
 
 
 __all__ = [

--- a/python/smqtk/utils/vptree/vpsb.py
+++ b/python/smqtk/utils/vptree/vpsb.py
@@ -127,8 +127,8 @@ def _vpsb_make_tree_inner(item_list, d, branching_factor, mu_selection):
 
     # Determine bounds of this node's children with respect to item distances
     # from the parent (current last distance in ``item.hist`` list).
-    # - All item histories at this point should be of the same length, so we can
-    #   pick the first one to determine level.
+    # - All item histories at this point should be of the same length, so we
+    #   can pick the first one to determine level.
     n.bounds = []
     node_level = len(item_list[0].hist)
     for hist_i in range(node_level):
@@ -175,27 +175,28 @@ def _vpsb_make_tree_inner(item_list, d, branching_factor, mu_selection):
         n.mu = numpy.partition(p_dists, mu_indices)[mu_indices]
     elif mu_selection == 'quantile':
         # Quantile method -- uneven spaced bins, even bin counts.
-        # - basically more accurate version of selection method (getting similar
-        #   results experimentally)
-        # - quantile probability array is evenly spaced and given +1 in order to
-        #   make the appropriate number of bins.
+        # - basically more accurate version of selection method (getting
+        #   similar results experimentally)
+        # - quantile probability array is evenly spaced and given +1 in order
+        #   to make the appropriate number of bins.
         quantile_probs = numpy.linspace(0, 1, children + 1)
-        p_dist_quantiles = scipy.stats.mstats.mquantiles(p_dists, quantile_probs)
+        p_dist_quantiles = scipy.stats.mstats.mquantiles(
+            p_dists, quantile_probs)
         # Mu values are the quantile values minus the min/max bounds.
         n.mu = p_dist_quantiles[1:-1]
     else:
         raise ValueError("Invalid mu selection method: %s" % mu_selection)
 
     # Sift items into bins based on mu values. Bins are in congruent order the
-    # the mu value list, which is in ascending order (smallest to largest), i.e.
-    # bin[0] are items closest to the vantage point and bin[-1] are items
+    # the mu value list, which is in ascending order (smallest to largest),
+    # i.e. bin[0] are items closest to the vantage point and bin[-1] are items
     # farthest away.
     item_bins = tuple([] for _ in range(children))
     dist_bins = [-INF] + list(n.mu) + [INF]
     for item, bin_i in itertools.izip(item_list,
                                       numpy.digitize(p_dists, dist_bins)):
         # need the -1 because digitize's return is 1-index.
-        item_bins[bin_i-1].append(item)
+        item_bins[bin_i - 1].append(item)
 
     # Recurse for each child bin in order.
     n.children = map(lambda b: _vpsb_make_tree_inner(b, d, branching_factor,
@@ -241,8 +242,8 @@ def vpsb_knn_recursive(q, k, root, dist_func):
         'k': k,
         'q_distance': q_dist,
         # "Max" heap of neighbors. Python heapq always builds min-heaps, so we
-        # store (-dist, node) elements. Most distance neighbor will always be at
-        # top of heap due to distance negation.
+        # store (-dist, node) elements. Most distance neighbor will always be
+        # at top of heap due to distance negation.
         'neighbors': [],
         # Initial search radius. Whole tree considered, so tau is infinite to
         # start.
@@ -259,7 +260,7 @@ def vpsb_knn_recursive(q, k, root, dist_func):
 
 def _vpsb_child_order_key(child, dist):
     """
-    Generate the key value for a child node for potential recursive search 
+    Generate the key value for a child node for potential recursive search
     order.
     """
     if child is None:


### PR DESCRIPTION
This PR integrates @Purg's [VP tree implementations](https://github.com/Kitware/SMQTK/tree/dev/vp-tree-utils) as a hash index (issue #177), which performs better (in terms of runtime of nearest-neighbor queries) than the existing Ball Tree index at almost any descriptor vector dimension and for almost any size tree, as shown below:

![near_neighbors_1-runtime-10000-dimension](https://user-images.githubusercontent.com/11039110/31615946-4b4fe5f8-b259-11e7-94ba-bd640edc7974.png)
![near_neighbors_1-runtime-4096-n](https://user-images.githubusercontent.com/11039110/31615964-559c91d2-b259-11e7-98b9-caedf11c1806.png)

These plots compare runtime for searching BT and VP indices with a query that differs from a stored descriptor vector by only a single bit (a worst-case scenario for VP trees). Similar plots for random queries (or queries that exactly match a stored descriptor vector) show even greater performance gains. Nearest neighbor results for these tests were also verified against a linear search to ensure the VP tree index searches are accurate.

The performance story for building VP vs BT indices is a bit more complicated, but BTs seem to build faster than VPs at lower dimension (< 4096) or smaller numbers (< 10000) of stored descriptors:

![build-runtime-10000-dimension](https://user-images.githubusercontent.com/11039110/31617385-07c24b10-b25d-11e7-9fb2-988f0225325c.png)
![build-runtime-4096-n](https://user-images.githubusercontent.com/11039110/31617456-41c7c5ec-b25d-11e7-8e1a-4c282c9e92fb.png)

There are parts of the VP tree implementations that could be further "numpyized," but at this point, profiling shows that the biggest bottleneck is calculating hamming distance between Python long ints. I'm pretty sure that improving on that will require a C implementation of popcount or something similar.