### PR TITLE
Fix postgres di batch execute

### DIFF
--- a/docs/release_notes/pending_release.md
+++ b/docs/release_notes/pending_release.md
@@ -8,3 +8,8 @@ Updates / New Features since v0.8.0
 
 Fixes since v0.8.0
 ------------------
+
+Descriptor Index Plugins
+
+* Fix bug in PostgreSQL plugin where the helper class was not being called
+  appropriately.

--- a/docs/release_notes/pending_release.md
+++ b/docs/release_notes/pending_release.md
@@ -13,3 +13,8 @@ Descriptor Index Plugins
 
 * Fix bug in PostgreSQL plugin where the helper class was not being called
   appropriately.
+
+Utilities
+
+* Fix bug in PostgreSQL connection helper where the connection object was
+  being called upon when it may not have been initialized.

--- a/python/smqtk/representation/descriptor_index/postgres.py
+++ b/python/smqtk/representation/descriptor_index/postgres.py
@@ -367,7 +367,8 @@ class PostgresDescriptorIndex (DescriptorIndex):
             cur.executemany(q, batch)
 
         self._log.debug("Adding many descriptors")
-        list(self.psql_helper.batch_execute(iter_elements(), exec_hook))
+        list(self.psql_helper.batch_execute(iter_elements(), exec_hook,
+                                            self.multiquery_batch_size))
 
     def get_descriptor(self, uuid):
         """
@@ -444,7 +445,8 @@ class PostgresDescriptorIndex (DescriptorIndex):
         #   - We also check that the number of rows we got back is the same
         #     as elements yielded, else there were trailing UUIDs that did not
         #     match anything in the database.
-        g = self.psql_helper.batch_execute(iterelems(), exec_hook, True)
+        g = self.psql_helper.batch_execute(iterelems(), exec_hook,
+                                           self.multiquery_batch_size, True)
         i = 0
         for r, expected_uuid in itertools.izip(g, uuid_order):
             d = pickle.loads(str(r[0]))

--- a/python/smqtk/utils/postgres.py
+++ b/python/smqtk/utils/postgres.py
@@ -344,9 +344,11 @@ class PsqlConnectionHelper (SmqtkObject):
                             for r in cur:
                                 yield r
 
-            conn.commit()
+            if conn is not None:
+                conn.commit()
         except:
-            conn.rollback()
+            if conn is not None:
+                conn.rollback()
             raise
         finally:
             # conn.__exit__ doesn't close connection, just the transaction

--- a/python/smqtk/utils/postgres.py
+++ b/python/smqtk/utils/postgres.py
@@ -267,9 +267,10 @@ class PsqlConnectionHelper (SmqtkObject):
             forward.
         :type cursor_callback: (psycopg2._psycopg.cursor, list) -> None
 
-        :param batch_size: Batch size limit. May be a positive integer, 0 or
-            None. A value of 0 or None means that no batching occurs and all
-            elements from the iterable are collected.
+        :param batch_size: Batch size limit when pulling elements from the input
+            iterable. May be a positive integer, 0 or None. A value of 0 or None
+            means that no batching occurs and all elements from the iterable are
+            collected.
 
             Once this number of elements are collected from the iterable, the
             callback is called with the collected batch of elements.


### PR DESCRIPTION
Addresses issue #334 where a call to the connection helper was not updated after an API update.

Also fixed a bug in the helper class where the connection was being referenced before it may have been initialized.