### PR TITLE
Removed miniconda installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,6 @@ addons:
       # For building things
       - cmake
 
-# Environment setup
-before_install:
-  # Setup local conda python environment
-  - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda2.sh
-  - bash miniconda2.sh -b -p $HOME/miniconda2
-  - export PATH="$HOME/miniconda2/bin:$PATH"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q --all
-  # Useful for debugging any issues with conda
-  - conda info -a
-
 # "Install" of SMQTK + immediate deps
 install:
   # install python dependencies to environment

--- a/docs/release_notes/pending_release.md
+++ b/docs/release_notes/pending_release.md
@@ -5,6 +5,11 @@ SMQTK Pending Release Notes
 Updates / New Features since v0.8.1
 -----------------------------------
 
+Travis CI
+
+- Removed use of Miniconda installation since it wasn't being utilized in
+  special way.
+
 
 Fixes since v0.8.1
 ------------------


### PR DESCRIPTION
Miniconda was not being used for anything specific so there doesn't seem
to be a reason to not use the travis container system python.  The
current use of miniconda also circumnavigates any python version
settings provided to travis.