### PR TITLE
Fix libsvm-hik relevancy index test

### DIFF
--- a/docs/release_notes/pending_release.md
+++ b/docs/release_notes/pending_release.md
@@ -16,3 +16,8 @@ Travis CI
 
 Fixes since v0.8.1
 ------------------
+
+Tests
+
+- Fixed ambiguous ordering check in libsvm-hik implementation of
+  RelevancyIndex algorithm.

--- a/python/smqtk/tests/algorithms/relevancy_index/test_svm_hik.py
+++ b/python/smqtk/tests/algorithms/relevancy_index/test_svm_hik.py
@@ -37,7 +37,7 @@ if LibSvmHikRelevancyIndex.is_usable():
                                      cls.d5, cls.d6]
 
             cls.q_pos = DescriptorMemoryElement('query', 0)
-            cls.q_pos.set_vector(np.array([.75, .25, 0, 0,  0], float))
+            cls.q_pos.set_vector(np.array([.75, .25, 0, 0, 0], float))
             cls.q_neg = DescriptorMemoryElement('query', 1)
             cls.q_neg.set_vector(np.array([0,   0,   0, .5, .5], float))
 
@@ -92,6 +92,10 @@ if LibSvmHikRelevancyIndex.is_usable():
             rank = iqr_index.rank([self.q_pos], [self.q_neg])
             rank_ordered = sorted(rank.items(), key=lambda e: e[1], reverse=True)
 
+            print("rank_ordered:")
+            for i, r in enumerate(rank_ordered):
+                print("..{}: {}".format(i, r))
+
             # Check expected ordering
             # 0-5-1-2-6-3-4
             # - 2 should end up coming before 6, because 6 has more intersection
@@ -99,7 +103,13 @@ if LibSvmHikRelevancyIndex.is_usable():
             ntools.assert_equal(rank_ordered[0][0], self.d0)
             ntools.assert_equal(rank_ordered[1][0], self.d5)
             ntools.assert_equal(rank_ordered[2][0], self.d1)
-            ntools.assert_equal(rank_ordered[3][0], self.d2)
-            ntools.assert_equal(rank_ordered[4][0], self.d6)
-            ntools.assert_equal(rank_ordered[5][0], self.d3)
-            ntools.assert_equal(rank_ordered[6][0], self.d4)
+            # Results show that d2 and d6 have the same rank, so their position
+            # in interchangeable.
+            assert rank_ordered[3][0] in (self.d2, self.d6)
+            assert rank_ordered[4][0] in (self.d2, self.d6)
+            assert rank_ordered[3][0] != rank_ordered[4][0]
+            # d3 and d4 evaluate to the same rank based on query (no
+            # intersection with positive, equal intersection with negative).
+            assert rank_ordered[5][0] in (self.d3, self.d4)
+            assert rank_ordered[6][0] in (self.d3, self.d4)
+            assert rank_ordered[5][0] != rank_ordered[6][0]


### PR DESCRIPTION
Descriptors 2/6 and 3/4 are equidistant in the test and may be in either order.