### PR TITLE
Patch/fix iqr playground docker

### DIFF
--- a/devops/docker/smqtk_iqr_playground/Dockerfile
+++ b/devops/docker/smqtk_iqr_playground/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 MAINTAINER paul.tunison@kitware.com
 
 # System Package dependencies
@@ -6,7 +6,9 @@ ENV TERM=xterm
 RUN rm /bin/sh \
  && ln -s /bin/bash /bin/sh \
  && apt-get -y update \
- && apt-get -y install git cmake curl vim less parallel
+ && apt-get -y install git cmake curl vim less parallel sudo \
+        # Additional packages implicitly brought in by nvidia cuda image
+        apt-transport-https build-essential bzip2
 
 
 # System Space #################################################################
@@ -23,22 +25,25 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" \
 
 
 # MongoDB installation
-# - Not using standard system install because that would cause a boost install
-#   version conflict with caffe. Caffe is more imporant here.
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 \
- && echo "deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -sc)/mongodb-org/3.0 multiverse" \
-    >/etc/apt/sources.list.d/mongodb-org-3.0.list \
+# - Using official package from MongoDB
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 \
+ && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" \
+    | tee /etc/apt/sources.list.d/mongodb-org-3.6.list \
  && apt-get -y update \
- && apt-get -y install mongodb-org
+    # Installing with specific version pin.
+ && apt-get -y install mongodb-org=3.6.5
 
 
 # Caffe system deps
 RUN apt-get -y install \
-    libatlas-base-dev libatlas-dev libboost1.55-all-dev libprotobuf-dev \
+    libatlas-base-dev libatlas-dev libboost1.58-all-dev libprotobuf-dev \
     protobuf-compiler libgoogle-glog-dev libgflags-dev libhdf5-dev
     # Optional: libopencv-dev liblmdb-dev libleveldb-dev libsnappy-dev
     # - See USE_* variabled in Caffe CMake configuration below.
 
+
+# SMQTK Plugin system deps
+RUN apt-get -y install postgresql-server-dev-9.4
 
 # User Space ###################################################################
 
@@ -56,7 +61,7 @@ RUN curl --insecure \
     >miniconda2-latest-linux-x86_64.sh \
  && bash miniconda2-latest-linux-x86_64.sh -b -p ${HOME}/miniconda \
  && rm miniconda2-latest-linux-x86_64.sh \
- && conda update --all
+ && conda update -y --all
 # - Some python niceties
 RUN pip install ipython
 
@@ -64,7 +69,7 @@ RUN pip install ipython
 # Caffe installation
 # - git hash is master as of 2016/10/05
 ENV CAFFE_URL="https://github.com/BVLC/caffe.git" \
-    CAFFE_VERSION=4ba654f5c88c36ee8ba53964b7faf25c6d7010b4
+    CAFFE_VERSION=1.0
 # - Python deps
 RUN pip install numpy scikit-image protobuf
 # - Get the source code
@@ -84,13 +89,12 @@ RUN mkdir caffe/build \
     -DPYTHON_INCLUDE_DIR:PATH=${HOME}/miniconda/include/python2.7 \
     -DPYTHON_INCLUDE_DIR2:PATH=${HOME}/miniconda/include/python2.7 \
     -DPYTHON_LIBRARY:PATH=${HOME}/miniconda/lib/libpython2.7.so \
-    -DUSE_CUDNN:BOOL=OFF \
     -DUSE_LEVELDB:BOOL=OFF \
     -DUSE_LMDB:BOOL=OFF \
     -DUSE_OPENCV:BOOL=OFF \
     -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/caffe/install \
     ${HOME}/caffe/source \
- && make -j12
+ && make -j$(nproc)
 # - "Install" python component with .pth file
 RUN echo "${HOME}/caffe/source/python" >miniconda/lib/python2.7/site-packages/caffe.pth
 # - Get basic model files
@@ -114,11 +118,9 @@ RUN mkdir smqtk/build \
     -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/miniconda \
     -DSMQTK_PIP_INSTALL_FLAGS:STRING="-e" \
     ${HOME}/smqtk/source \
- && make install -j12
+ && make install -j$(nproc)
 # - added optional plugin requirements
-RUN sudo apt-get -y update \
- && sudo apt-get -y install postgresql-server-dev-9.4 \
- && pip install psycopg2
+RUN pip install psycopg2
 # Expected volume mount directories
 RUN mkdir -p data/{images,models,configs,logs,db.psql,db.mongo}
 

--- a/devops/docker/smqtk_iqr_playground/Dockerfile.nvidia
+++ b/devops/docker/smqtk_iqr_playground/Dockerfile.nvidia
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:8.0
+FROM nvidia/cuda:8.0-cudnn7-devel
 MAINTAINER paul.tunison@kitware.com
 
 # System Package dependencies
@@ -6,7 +6,7 @@ ENV TERM=xterm
 RUN rm /bin/sh \
  && ln -s /bin/bash /bin/sh \
  && apt-get -y update \
- && apt-get -y install git cmake curl vim less parallel
+ && apt-get -y install git cmake curl vim less parallel sudo
 
 
 # System Space #################################################################
@@ -23,22 +23,25 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main" \
 
 
 # MongoDB installation
-# - Not using standard system install because that would cause a boost install
-#   version conflict with caffe. Caffe is more imporant here.
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 \
- && echo "deb http://repo.mongodb.org/apt/ubuntu $(lsb_release -sc)/mongodb-org/3.0 multiverse" \
-    >/etc/apt/sources.list.d/mongodb-org-3.0.list \
+# - Using official package from MongoDB
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5 \
+ && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" \
+    | tee /etc/apt/sources.list.d/mongodb-org-3.6.list \
  && apt-get -y update \
- && apt-get -y install mongodb-org
+    # Installing with specific version pin.
+ && apt-get -y install mongodb-org=3.6.5
 
 
 # Caffe system deps
 RUN apt-get -y install \
-    libatlas-base-dev libatlas-dev libboost1.55-all-dev libprotobuf-dev \
+    libatlas-base-dev libatlas-dev libboost1.58-all-dev libprotobuf-dev \
     protobuf-compiler libgoogle-glog-dev libgflags-dev libhdf5-dev
     # Optional: libopencv-dev liblmdb-dev libleveldb-dev libsnappy-dev
     # - See USE_* variabled in Caffe CMake configuration below.
 
+
+# SMQTK Plugin system deps
+RUN apt-get -y install postgresql-server-dev-9.4
 
 # User Space ###################################################################
 
@@ -56,7 +59,7 @@ RUN curl --insecure \
     >miniconda2-latest-linux-x86_64.sh \
  && bash miniconda2-latest-linux-x86_64.sh -b -p ${HOME}/miniconda \
  && rm miniconda2-latest-linux-x86_64.sh \
- && conda update --all
+ && conda update -y --all
 # - Some python niceties
 RUN pip install ipython
 
@@ -64,7 +67,7 @@ RUN pip install ipython
 # Caffe installation
 # - git hash is master as of 2016/10/05
 ENV CAFFE_URL="https://github.com/BVLC/caffe.git" \
-    CAFFE_VERSION=4ba654f5c88c36ee8ba53964b7faf25c6d7010b4
+    CAFFE_VERSION=1.0
 # - Python deps
 RUN pip install numpy scikit-image protobuf
 # - Get the source code
@@ -81,6 +84,7 @@ RUN mkdir caffe/build \
     -DCMAKE_BUILD_TYPE:STRING=Release \
     -DCPU_ONLY:BOOL=OFF \
     -DCUDA_ARCH_NAME:STRING=Manual \
+     # Add new NVIDIA GPU architecture version to this list as appropriate.
     -DCUDA_ARCH_BIN:STRING="30 32 35 37 50 52 53 60 61 62" \
     -DCUDA_ARCH_PTX:STRING="" \
     -DPYTHON_EXECUTABLE:PATH=${HOME}/miniconda/bin/python2.7 \
@@ -93,7 +97,7 @@ RUN mkdir caffe/build \
     -DUSE_OPENCV:BOOL=OFF \
     -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/caffe/install \
     ${HOME}/caffe/source \
- && make -j12
+ && make -j$(nproc)
 # - "Install" python component with .pth file
 RUN echo "${HOME}/caffe/source/python" >miniconda/lib/python2.7/site-packages/caffe.pth
 # - Get basic model files
@@ -117,11 +121,9 @@ RUN mkdir smqtk/build \
     -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/miniconda \
     -DSMQTK_PIP_INSTALL_FLAGS:STRING="-e" \
     ${HOME}/smqtk/source \
- && make install -j12
+ && make install -j$(nproc)
 # - added optional plugin requirements
-RUN sudo apt-get -y update \
- && sudo apt-get -y install postgresql-server-dev-9.4 \
- && pip install psycopg2
+RUN pip install psycopg2
 # Expected volume mount directories
 RUN mkdir -p data/{images,models,configs,logs,db.psql,db.mongo}
 

--- a/devops/docker/smqtk_iqr_playground/README.md
+++ b/devops/docker/smqtk_iqr_playground/README.md
@@ -47,9 +47,9 @@ recursively in the mounted directory (uses command ``find <dir> -type f``):
 
     OR
 
-    nvidia-docker run -d -v <abs-img-dir>:/home/smqtk/data/images -p 5000:5000 kitware/smqtk/iqr_playground_nvidia -b [-t]
+    docker run -d --runtime nvidia -v <abs-img-dir>:/home/smqtk/data/images -p 5000:5000 kitware/smqtk/iqr_playground_nvidia -b [-t]
 
-The use of ``nvidia-docker`` is required to use the GPU computation
+The use of ``--runtime nvidia`` is required to use the GPU computation
 capabilities (default options, can be changed and described later).
 The ``-v`` option above shows where to mount a directory of images for
 processing. The ``-p`` option above shows the default IQR web-app server port

--- a/devops/docker/smqtk_iqr_playground/default_confs/compute_hash_codes.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/compute_hash_codes.json
@@ -16,20 +16,46 @@
             },
             "type": "PostgresDescriptorIndex"
         },
+        "hash2uuid_kvstore": {
+            "MemoryKeyValueStore": {
+                "cache_element": {
+                    "DataFileElement": {
+                        "explicit_mimetype": null,
+                        "filepath": "models/LSH.hash2uuids.pickle",
+                        "readonly": false
+                    },
+                    "type": "DataFileElement"
+                }
+            },
+            "type": "MemoryKeyValueStore"
+        },
         "lsh_functor": {
             "ItqFunctor": {
                 "bit_length": 256,
                 "itq_iterations": 100,
-                "mean_vec_filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                "mean_vec_cache": {
+                    "DataFileElement": {
+                        "explicit_mimetype": null,
+                        "filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                        "readonly": true
+                    },
+                    "type": "DataFileElement"
+                },
                 "normalize": null,
                 "random_seed": 0,
-                "rotation_filepath": "models/itq.model.b256_i100_r0.rotation.npy"
+                "rotation_cache": {
+                    "DataFileElement": {
+                        "explicit_mimetype": null,
+                        "filepath": "models/itq.model.b256_i100_r0.rotation.npy",
+                        "readonly": true
+                    },
+                    "type": "DataFileElement"
+                }
             },
             "type": "ItqFunctor"
         }
     },
     "utility": {
-        "pickle_protocol": -1,
         "report_interval": 1.0,
         "use_multiprocessing": false
     }

--- a/devops/docker/smqtk_iqr_playground/default_confs/cpu/compute_many_descriptors.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/cpu/compute_many_descriptors.json
@@ -1,29 +1,19 @@
 {
     "descriptor_factory": {
-        "PostgresDescriptorElement": {
-            "binary_col": "vector",
-            "db_host": "/dev/shm",
-            "db_name": "postgres",
-            "db_pass": null,
-            "db_port": 5432,
-            "db_user": "smqtk",
-            "table_name": "descriptors_alexnet_fc7",
-            "type_col": "type_str",
-            "uuid_col": "uid"
-        },
-        "type": "PostgresDescriptorElement"
+        "DescriptorMemoryElement": {},
+        "type": "DescriptorMemoryElement"
     },
     "descriptor_generator": {
         "CaffeDescriptorGenerator": {
             "batch_size": 100,
             "data_layer": "data",
             "gpu_device_id": 0,
-            "image_mean_filepath": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
+            "image_mean_uri": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
             "input_scale": null,
             "load_truncated_images": true,
             "network_is_bgr": true,
-            "network_model_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
-            "network_prototxt_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
+            "network_model_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
+            "network_prototxt_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
             "pixel_rescale": null,
             "return_layer": "fc7",
             "use_gpu": false
@@ -48,7 +38,14 @@
     },
     "optional_data_set": {
         "DataMemorySet": {
-            "file_cache": "models/image_elements.dms_cache",
+            "cache_element": {
+                "DataFileElement": {
+                    "explicit_mimetype": null,
+                    "filepath": "models/image_elements.dms_cache",
+                    "readonly": false
+                },
+                "type": "DataFileElement"
+            },
             "pickle_protocol": -1
         },
         "type": "DataMemorySet"

--- a/devops/docker/smqtk_iqr_playground/default_confs/cpu/runApp.IqrSearchDispatcher.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/cpu/runApp.IqrSearchDispatcher.json
@@ -8,7 +8,14 @@
         "Data-set Iqr": {
             "data_set": {
                 "DataMemorySet": {
-                    "file_cache": "models/image_elements.dms_cache",
+                    "cache_element": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/image_elements.dms_cache",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    },
                     "pickle_protocol": -1
                 },
                 "type": "DataMemorySet"
@@ -18,12 +25,12 @@
                     "batch_size": 100,
                     "data_layer": "data",
                     "gpu_device_id": 0,
-                    "image_mean_filepath": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
+                    "image_mean_uri": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
                     "input_scale": null,
                     "load_truncated_images": true,
                     "network_is_bgr": true,
-                    "network_model_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
-                    "network_prototxt_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
+                    "network_model_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
+                    "network_prototxt_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
                     "pixel_rescale": null,
                     "return_layer": "fc7",
                     "use_gpu": false
@@ -31,18 +38,8 @@
                 "type": "CaffeDescriptorGenerator"
             },
             "descriptor_factory": {
-                "PostgresDescriptorElement": {
-                    "binary_col": "vector",
-                    "db_host": "/dev/shm",
-                    "db_name": "postgres",
-                    "db_pass": null,
-                    "db_port": 5432,
-                    "db_user": "smqtk",
-                    "table_name": "descriptors_alexnet_fc7",
-                    "type_col": "type_str",
-                    "uuid_col": "uid"
-                },
-                "type": "PostgresDescriptorElement"
+                "DescriptorMemoryElement": {},
+                "type": "DescriptorMemoryElement"
             },
             "nn_index": {
                 "LSHNearestNeighborIndex": {
@@ -63,30 +60,60 @@
                         "type": "PostgresDescriptorIndex"
                     },
                     "distance_method": "cosine",
-                    "hash2uuid_cache_filepath": "models/LSH.hash2uuids.pickle",
+                    "hash2uuids_kvstore": {
+                        "MemoryKeyValueStore": {
+                            "cache_element": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/LSH.hash2uuids.pickle",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            }
+                        },
+                        "type": "MemoryKeyValueStore"
+                    },
                     "hash_index": {
                         "SkLearnBallTreeHashIndex": {
-                            "file_cache": "models/balltree_hash_index.npz",
+                            "cache_element": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/balltree_hash_index.npz",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            },
                             "leaf_size": 40,
                             "random_seed": 0
                         },
                         "type": "SkLearnBallTreeHashIndex"
                     },
-                    "live_reload": false,
                     "lsh_functor": {
                         "ItqFunctor": {
                             "bit_length": 256,
                             "itq_iterations": 100,
-                            "mean_vec_filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                            "mean_vec_cache": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            },
                             "normalize": null,
                             "random_seed": 0,
-                            "rotation_filepath": "models/itq.model.b256_i100_r0.rotation.npy"
+                            "rotation_cache": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/itq.model.b256_i100_r0.rotation.npy",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            }
                         },
                         "type": "ItqFunctor"
                     },
-                    "read_only": true,
-                    "reload_mon_interval": 0.1,
-                    "reload_settle_window": 1.0
+                    "read_only": true
                 },
                 "type": "LSHNearestNeighborIndex"
             },

--- a/devops/docker/smqtk_iqr_playground/default_confs/cpu/runApp.NearestNeighborServiceServer.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/cpu/runApp.NearestNeighborServiceServer.json
@@ -1,29 +1,19 @@
 {
     "descriptor_factory": {
-        "PostgresDescriptorElement": {
-            "binary_col": "vector",
-            "db_host": "/dev/shm",
-            "db_name": "postgres",
-            "db_pass": null,
-            "db_port": 5432,
-            "db_user": "smqtk",
-            "table_name": "descriptors_alexnet_fc7",
-            "type_col": "type_str",
-            "uuid_col": "uid"
-        },
-        "type": "PostgresDescriptorElement"
+        "DescriptorMemoryElement": {},
+        "type": "DescriptorMemoryElement"
     },
     "descriptor_generator": {
         "CaffeDescriptorGenerator": {
             "batch_size": 100,
             "data_layer": "data",
             "gpu_device_id": 0,
-            "image_mean_filepath": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
+            "image_mean_uri": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
             "input_scale": null,
-            "load_truncated_images": false,
+            "load_truncated_images": true,
             "network_is_bgr": true,
-            "network_model_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
-            "network_prototxt_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
+            "network_model_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
+            "network_prototxt_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
             "pixel_rescale": null,
             "return_layer": "fc7",
             "use_gpu": false
@@ -70,30 +60,60 @@
                 "type": "PostgresDescriptorIndex"
             },
             "distance_method": "cosine",
-            "hash2uuid_cache_filepath": "models/LSH.hash2uuids.pickle",
+            "hash2uuids_kvstore": {
+                "MemoryKeyValueStore": {
+                    "cache_element": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/LSH.hash2uuids.pickle",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    }
+                },
+                "type": "MemoryKeyValueStore"
+            },
             "hash_index": {
                 "SkLearnBallTreeHashIndex": {
-                    "file_cache": "models/balltree_hash_index.npz",
+                    "cache_element": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/balltree_hash_index.npz",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    },
                     "leaf_size": 40,
                     "random_seed": 0
                 },
                 "type": "SkLearnBallTreeHashIndex"
             },
-            "live_reload": false,
             "lsh_functor": {
                 "ItqFunctor": {
                     "bit_length": 256,
                     "itq_iterations": 100,
-                    "mean_vec_filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                    "mean_vec_cache": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    },
                     "normalize": null,
                     "random_seed": 0,
-                    "rotation_filepath": "models/itq.model.b256_i100_r0.rotation.npy"
+                    "rotation_cache": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/itq.model.b256_i100_r0.rotation.npy",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    }
                 },
                 "type": "ItqFunctor"
             },
             "read_only": true,
-            "reload_mon_interval": 0.1,
-            "reload_settle_window": 1.0
         },
         "type": "LSHNearestNeighborIndex"
     },

--- a/devops/docker/smqtk_iqr_playground/default_confs/entrypoint.conf
+++ b/devops/docker/smqtk_iqr_playground/default_confs/entrypoint.conf
@@ -25,6 +25,7 @@ SMQTK_GEN_IMG_TILES="generate_image_transform.tiles.json"
 SMQTK_CMD_CONFIG="compute_many_descriptors.json"
 SMQTK_ITQ_TRAIN_CONFIG="train_itq.json"
 SMQTK_CHC_CONFIG="compute_hash_codes.json"
+SMQTK_BALLTREE_CONFIG="make_balltree.json"
 SMQTK_IQR_CONFIG="runApp.IqrSearchDispatcher.json"
 SMQTK_REST_IQR_CONFIG="runApp.IqrService.json"
 SMQTK_REST_NNSS_CONFIG="runApp.NearestNeighborServiceServer.json"
@@ -45,14 +46,3 @@ DESCRIPTOR_BATCH_SIZE=100
 # Will be written to models directory if computed. Otherwise not read by this
 # application.
 DESCRIPTOR_PROCESSED_CSV="cmd_processed.csv"
-
-# Bit-size of ITQ model trained
-ITQ_BIT_SIZE=256
-HASH2UUID_MAP="LSH.hash2uuids.pickle"
-
-# Leaf-size of balltree to build
-BALLTREE_LEAFSIZE=40
-# Random seed to use for building balltree
-BALLTREE_RAND_SEED=0
-# Path to the output balltree model file
-BALLTREE_MODEL="balltree_hash_index.npz"

--- a/devops/docker/smqtk_iqr_playground/default_confs/gpu/compute_many_descriptors.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/gpu/compute_many_descriptors.json
@@ -1,29 +1,19 @@
 {
     "descriptor_factory": {
-        "PostgresDescriptorElement": {
-            "binary_col": "vector",
-            "db_host": "/dev/shm",
-            "db_name": "postgres",
-            "db_pass": null,
-            "db_port": 5432,
-            "db_user": "smqtk",
-            "table_name": "descriptors_alexnet_fc7",
-            "type_col": "type_str",
-            "uuid_col": "uid"
-        },
-        "type": "PostgresDescriptorElement"
+        "DescriptorMemoryElement": {},
+        "type": "DescriptorMemoryElement"
     },
     "descriptor_generator": {
         "CaffeDescriptorGenerator": {
             "batch_size": 100,
             "data_layer": "data",
             "gpu_device_id": 0,
-            "image_mean_filepath": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
+            "image_mean_uri": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
             "input_scale": null,
             "load_truncated_images": true,
             "network_is_bgr": true,
-            "network_model_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
-            "network_prototxt_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
+            "network_model_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
+            "network_prototxt_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
             "pixel_rescale": null,
             "return_layer": "fc7",
             "use_gpu": true
@@ -48,7 +38,14 @@
     },
     "optional_data_set": {
         "DataMemorySet": {
-            "file_cache": "models/image_elements.dms_cache",
+            "cache_element": {
+                "DataFileElement": {
+                    "explicit_mimetype": null,
+                    "filepath": "models/image_elements.dms_cache",
+                    "readonly": false
+                },
+                "type": "DataFileElement"
+            },
             "pickle_protocol": -1
         },
         "type": "DataMemorySet"

--- a/devops/docker/smqtk_iqr_playground/default_confs/gpu/runApp.IqrSearchDispatcher.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/gpu/runApp.IqrSearchDispatcher.json
@@ -8,7 +8,14 @@
         "Data-set Iqr": {
             "data_set": {
                 "DataMemorySet": {
-                    "file_cache": "models/image_elements.dms_cache",
+                    "cache_element": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/image_elements.dms_cache",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    },
                     "pickle_protocol": -1
                 },
                 "type": "DataMemorySet"
@@ -18,12 +25,12 @@
                     "batch_size": 100,
                     "data_layer": "data",
                     "gpu_device_id": 0,
-                    "image_mean_filepath": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
+                    "image_mean_uri": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
                     "input_scale": null,
                     "load_truncated_images": true,
                     "network_is_bgr": true,
-                    "network_model_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
-                    "network_prototxt_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
+                    "network_model_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
+                    "network_prototxt_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
                     "pixel_rescale": null,
                     "return_layer": "fc7",
                     "use_gpu": true
@@ -31,18 +38,8 @@
                 "type": "CaffeDescriptorGenerator"
             },
             "descriptor_factory": {
-                "PostgresDescriptorElement": {
-                    "binary_col": "vector",
-                    "db_host": "/dev/shm",
-                    "db_name": "postgres",
-                    "db_pass": null,
-                    "db_port": 5432,
-                    "db_user": "smqtk",
-                    "table_name": "descriptors_alexnet_fc7",
-                    "type_col": "type_str",
-                    "uuid_col": "uid"
-                },
-                "type": "PostgresDescriptorElement"
+                "DescriptorMemoryElement": {},
+                "type": "DescriptorMemoryElement"
             },
             "nn_index": {
                 "LSHNearestNeighborIndex": {
@@ -63,30 +60,60 @@
                         "type": "PostgresDescriptorIndex"
                     },
                     "distance_method": "cosine",
-                    "hash2uuid_cache_filepath": "models/LSH.hash2uuids.pickle",
+                    "hash2uuids_kvstore": {
+                        "MemoryKeyValueStore": {
+                            "cache_element": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/LSH.hash2uuids.pickle",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            }
+                        },
+                        "type": "MemoryKeyValueStore"
+                    },
                     "hash_index": {
                         "SkLearnBallTreeHashIndex": {
-                            "file_cache": "models/balltree_hash_index.npz",
+                            "cache_element": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/balltree_hash_index.npz",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            },
                             "leaf_size": 40,
                             "random_seed": 0
                         },
                         "type": "SkLearnBallTreeHashIndex"
                     },
-                    "live_reload": false,
                     "lsh_functor": {
                         "ItqFunctor": {
                             "bit_length": 256,
                             "itq_iterations": 100,
-                            "mean_vec_filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                            "mean_vec_cache": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            },
                             "normalize": null,
                             "random_seed": 0,
-                            "rotation_filepath": "models/itq.model.b256_i100_r0.rotation.npy"
+                            "rotation_cache": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/itq.model.b256_i100_r0.rotation.npy",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            }
                         },
                         "type": "ItqFunctor"
                     },
-                    "read_only": true,
-                    "reload_mon_interval": 0.1,
-                    "reload_settle_window": 1.0
+                    "read_only": true
                 },
                 "type": "LSHNearestNeighborIndex"
             },

--- a/devops/docker/smqtk_iqr_playground/default_confs/gpu/runApp.NearestNeighborServiceServer.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/gpu/runApp.NearestNeighborServiceServer.json
@@ -1,29 +1,19 @@
 {
     "descriptor_factory": {
-        "PostgresDescriptorElement": {
-            "binary_col": "vector",
-            "db_host": "/dev/shm",
-            "db_name": "postgres",
-            "db_pass": null,
-            "db_port": 5432,
-            "db_user": "smqtk",
-            "table_name": "descriptors_alexnet_fc7",
-            "type_col": "type_str",
-            "uuid_col": "uid"
-        },
-        "type": "PostgresDescriptorElement"
+        "DescriptorMemoryElement": {},
+        "type": "DescriptorMemoryElement"
     },
     "descriptor_generator": {
         "CaffeDescriptorGenerator": {
             "batch_size": 100,
             "data_layer": "data",
             "gpu_device_id": 0,
-            "image_mean_filepath": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
+            "image_mean_uri": "/home/smqtk/caffe/source/data/ilsvrc12/imagenet_mean.binaryproto",
             "input_scale": null,
-            "load_truncated_images": false,
+            "load_truncated_images": true,
             "network_is_bgr": true,
-            "network_model_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
-            "network_prototxt_filepath": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
+            "network_model_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/bvlc_alexnet.caffemodel",
+            "network_prototxt_uri": "/home/smqtk/caffe/source/models/bvlc_alexnet/deploy.prototxt",
             "pixel_rescale": null,
             "return_layer": "fc7",
             "use_gpu": true
@@ -70,30 +60,60 @@
                 "type": "PostgresDescriptorIndex"
             },
             "distance_method": "cosine",
-            "hash2uuid_cache_filepath": "models/LSH.hash2uuids.pickle",
+            "hash2uuids_kvstore": {
+                "MemoryKeyValueStore": {
+                    "cache_element": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/LSH.hash2uuids.pickle",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    }
+                },
+                "type": "MemoryKeyValueStore"
+            },
             "hash_index": {
                 "SkLearnBallTreeHashIndex": {
-                    "file_cache": "models/balltree_hash_index.npz",
+                    "cache_element": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/balltree_hash_index.npz",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    },
                     "leaf_size": 40,
                     "random_seed": 0
                 },
                 "type": "SkLearnBallTreeHashIndex"
             },
-            "live_reload": false,
             "lsh_functor": {
                 "ItqFunctor": {
                     "bit_length": 256,
                     "itq_iterations": 100,
-                    "mean_vec_filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                    "mean_vec_cache": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    },
                     "normalize": null,
                     "random_seed": 0,
-                    "rotation_filepath": "models/itq.model.b256_i100_r0.rotation.npy"
+                    "rotation_cache": {
+                        "DataFileElement": {
+                            "explicit_mimetype": null,
+                            "filepath": "models/itq.model.b256_i100_r0.rotation.npy",
+                            "readonly": true
+                        },
+                        "type": "DataFileElement"
+                    }
                 },
                 "type": "ItqFunctor"
             },
             "read_only": true,
-            "reload_mon_interval": 0.1,
-            "reload_settle_window": 1.0
         },
         "type": "LSHNearestNeighborIndex"
     },

--- a/devops/docker/smqtk_iqr_playground/default_confs/make_balltree.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/make_balltree.json
@@ -1,0 +1,28 @@
+{
+    "hash2uuid_kv_store": {
+        "MemoryKeyValueStore": {
+            "cache_element": {
+                "DataFileElement": {
+                    "explicit_mimetype": null,
+                    "filepath": "models/LSH.hash2uuids.pickle",
+                    "readonly": true
+                },
+                "type": "DataFileElement"
+            }
+        },
+        "type": "MemoryKeyValueStore"
+    },
+    "itq_bit_length": 256,
+    "sklearn_balltree": {
+        "cache_element": {
+            "DataFileElement": {
+                "explicit_mimetype": null,
+                "filepath": "models/balltree_hash_index.npz",
+                "readonly": false
+            },
+            "type": "DataFileElement"
+        },
+        "leaf_size": 40,
+        "random_seed": 0
+    }
+}

--- a/devops/docker/smqtk_iqr_playground/default_confs/runApp.IqrService.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/runApp.IqrService.json
@@ -20,8 +20,8 @@
             "classifier_config": {
                 "LibSvmClassifier": {
                     "normalize": 2,
-                    "svm_label_map_fp": null,
-                    "svm_model_fp": null,
+                    "svm_label_map_uri": null,
+                    "svm_model_uri": null,
                     "train_params": {
                         "-b": 1,
                         "-c": 2,
@@ -66,30 +66,60 @@
                         "type": "PostgresDescriptorIndex"
                     },
                     "distance_method": "cosine",
-                    "hash2uuid_cache_filepath": "models/LSH.hash2uuids.pickle",
+                    "hash2uuids_kvstore": {
+                        "MemoryKeyValueStore": {
+                            "cache_element": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/LSH.hash2uuids.pickle",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            }
+                        },
+                        "type": "MemoryKeyValueStore"
+                    },
                     "hash_index": {
                         "SkLearnBallTreeHashIndex": {
-                            "file_cache": "models/balltree_hash_index.npz",
+                            "cache_element": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/balltree_hash_index.npz",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            },
                             "leaf_size": 40,
                             "random_seed": 0
                         },
                         "type": "SkLearnBallTreeHashIndex"
                     },
-                    "live_reload": false,
                     "lsh_functor": {
                         "ItqFunctor": {
                             "bit_length": 256,
                             "itq_iterations": 100,
-                            "mean_vec_filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                            "mean_vec_cache": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            },
                             "normalize": null,
                             "random_seed": 0,
-                            "rotation_filepath": "models/itq.model.b256_i100_r0.rotation.npy"
+                            "rotation_cache": {
+                                "DataFileElement": {
+                                    "explicit_mimetype": null,
+                                    "filepath": "models/itq.model.b256_i100_r0.rotation.npy",
+                                    "readonly": true
+                                },
+                                "type": "DataFileElement"
+                            }
                         },
                         "type": "ItqFunctor"
                     },
                     "read_only": true,
-                    "reload_mon_interval": 0.1,
-                    "reload_settle_window": 1.0
                 },
                 "type": "LSHNearestNeighborIndex"
             },

--- a/devops/docker/smqtk_iqr_playground/default_confs/train_itq.json
+++ b/devops/docker/smqtk_iqr_playground/default_confs/train_itq.json
@@ -18,10 +18,24 @@
     "itq_config": {
         "bit_length": 256,
         "itq_iterations": 100,
-        "mean_vec_filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+        "mean_vec_cache": {
+            "DataFileElement": {
+                "explicit_mimetype": null,
+                "filepath": "models/itq.model.b256_i100_r0.mean_vec.npy",
+                "readonly": false
+            },
+            "type": "DataFileElement"
+        },
         "normalize": null,
         "random_seed": 0,
-        "rotation_filepath": "models/itq.model.b256_i100_r0.rotation.npy"
+        "rotation_cache": {
+            "DataFileElement": {
+                "explicit_mimetype": null,
+                "filepath": "models/itq.model.b256_i100_r0.rotation.npy",
+                "readonly": false
+            },
+            "type": "DataFileElement"
+        }
     },
     "uuids_list_filepath": null
 }

--- a/devops/docker/smqtk_iqr_playground/entrypoint.sh
+++ b/devops/docker/smqtk_iqr_playground/entrypoint.sh
@@ -222,7 +222,6 @@ then
     then
         compute_hash_codes \
             -v -c "${CONFIG_DIR}/${SMQTK_CHC_CONFIG}" \
-            --output-hash2uuids "${MODEL_DIR}/${HASH2UUID_MAP}" \
             &> "${LOG_CHC}"
         touch "${STP_CHC}"
     fi
@@ -230,9 +229,7 @@ then
     # Compute balltree hash index
     if [ ! -e "${STP_MBT}" ]
     then
-        make_balltree "${MODEL_DIR}/${HASH2UUID_MAP}" ${ITQ_BIT_SIZE} \
-            ${BALLTREE_LEAFSIZE} ${BALLTREE_RAND_SEED} \
-            "${MODEL_DIR}/${BALLTREE_MODEL}" \
+        make_balltree -v -c "${CONFIG_DIR}/${SMQTK_BALLTREE_CONFIG}" \
             &> "${LOG_MBT}"
         touch "${STP_MBT}"
     fi
@@ -275,9 +272,9 @@ then
   }
   function smqtk_cleanup() {
     echo "Stopping IQR REST Service"
-    kill -${signal} $(cat "${SMQTK_REST_IQR_PID}")
+    kill -${1} $(cat "${SMQTK_REST_IQR_PID}")
     echo "Stopping NN REST Service"
-    kill -${signal} $(cat "${SMQTK_REST_NNSS_PID}")
+    kill -${1} $(cat "${SMQTK_REST_NNSS_PID}")
   }
   function smqtk_pid_cleanup() {
     echo "Cleaning NN/IQR PID files"
@@ -303,7 +300,7 @@ else
   }
   function smqtk_cleanup() {
     echo "Stopping IQR GUI app"
-    kill -${signal} $(cat "${SMQTK_IQR_PID}")
+    kill -${1} $(cat "${SMQTK_IQR_PID}")
   }
   function smqtk_pid_cleanup() {
     echo "Cleaning IQR App PID file"

--- a/devops/docker/smqtk_iqr_playground/run_container.gpu.sh
+++ b/devops/docker/smqtk_iqr_playground/run_container.gpu.sh
@@ -19,7 +19,7 @@ if [ -z "$( docker ps -a | grep "${CONTAINER_NAME}" 2>/dev/null )" ]
 then
   IMAGE_DIR="$1"
   shift
-  nvidia-docker run -d -p ${IQR_PORT_PUBLISH}:5000 -v "${IMAGE_DIR}":/home/smqtk/data/images --name "${CONTAINER_NAME}" \
+  docker run -d --runtime nvidia -p ${IQR_PORT_PUBLISH}:5000 -v "${IMAGE_DIR}":/home/smqtk/data/images --name "${CONTAINER_NAME}" \
     ${IQR_CONTAINER}:${IQR_CONTAINER_VERSION} -b "$@"
 fi
 

--- a/docs/release_notes/pending_patch.md
+++ b/docs/release_notes/pending_patch.md
@@ -1,0 +1,9 @@
+SMQTK Pending Patch Notes
+===========================
+
+Fixes since v0.8.1
+------------------
+
+Docker
+
+* Fix IQR Playground docker image configuration files.

--- a/docs/release_notes/pending_patch.md
+++ b/docs/release_notes/pending_patch.md
@@ -6,4 +6,5 @@ Fixes since v0.8.1
 
 Docker
 
-* Fix IQR Playground docker image configuration files.
+* Fix IQR Playground docker image build and configuration files, upgraded base
+  image to Xenial from Trusty.


### PR DESCRIPTION
Patch update to SMQTK to fix IQR docker image functionality for toolkit updates since last revision.  This mainly fixes/updates:

- docker image OS version to Xenial (and nvidia/cuda image from 8.0 to 8.0-cudnn7-devel)
- caffe 1 version (and its dependencies) to 1.0.
- fix (by updating) mongo installation
- configuration file updates for updated APIs