### PR TITLE
Fix PSQL KeyValueStore implementation for python 2/3 compatibility

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -9,3 +9,10 @@ Updates / New Features
 Fixes
 -----
 
+Representation
+
+- ``KeyValueStore``
+
+  - PostgreSQL
+
+    - Fix python<->SQL bytea conversion functions for python 2/3 compatibility.


### PR DESCRIPTION
The python instance to psycopg2 binary object conversion was not
operating correctly in python 3.  This updates the method to be cross
compatible as well as updates the tests to use cross compatible
accessors.