### PR TITLE
Fix boolean flag passed to HTML input autocomplete property

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -9,3 +9,7 @@ Updates / New Features
 Fixes
 -----
 
+Web
+   - IQR Search Demo App
+      - Fixed input element autocomplete property value being set from
+        disabled" to the correct value of "off".

--- a/python/smqtk/web/search_app/modules/login/templates/login.html
+++ b/python/smqtk/web/search_app/modules/login/templates/login.html
@@ -17,7 +17,7 @@
             </div>
             <div class="control-group">
                 <label for="password">Password</label>
-                <input autocomplete="disabled" class="input-block" id="password"
+                <input autocomplete="off" class="input-block" id="password"
                        name="passwd" tabindex="2" type="password"/>
             </div>
             <div class="control-group">


### PR DESCRIPTION
Minor fix that corrects the "off" value being set to the autocomplete flag in the login form.