### PR TITLE
[WIP] Add ability to limit ITQ training memory usage

### DIFF
--- a/python/smqtk/bin/train_itq.py
+++ b/python/smqtk/bin/train_itq.py
@@ -9,10 +9,16 @@ The ``uuids_list_filepath`` configuration property is optional and should
 be used to specify a sub-set of descriptors in the configured index to
 train on. This only works if the stored descriptors' UUID is a type of
 string.
+
+The ``max_descriptors'' configuration property is optional and can be
+used to cap the number of descriptors used to train the model.  If
+more descriptors are available than requested, they are randomly
+subsampled.
 """
 
 import logging
 import os.path
+import random
 
 from smqtk.algorithms.nn_index.lsh.functors.itq import ItqFunctor
 from smqtk.representation import (
@@ -32,11 +38,25 @@ def default_config():
         "itq_config": ItqFunctor.get_default_config(),
         "uuids_list_filepath": None,
         "descriptor_index": plugin.make_config(get_descriptor_index_impls()),
+        "max_descriptors": None,
     }
 
 
 def cli_parser():
     return bin_utils.basic_cli_parser(__doc__)
+
+
+def subsample(it, x, length):
+    """Given an iterable it that has length length, return an iterable
+    that consumes it and produces x elements by taking a random sample
+    from it.
+
+    """
+    for elem in it:
+        if random.random() * length < x:
+            yield elem
+            x -= 1
+        length -= 1
 
 
 def main():
@@ -45,6 +65,7 @@ def main():
     log = logging.getLogger(__name__)
 
     uuids_list_filepath = config['uuids_list_filepath']
+    max_descriptors = config['max_descriptors']
 
     log.info("Initializing ITQ functor")
     #: :type: smqtk.algorithms.nn_index.lsh.functors.itq.ItqFunctor
@@ -63,12 +84,25 @@ def main():
             with open(uuids_list_filepath) as f:
                 for l in f:
                     yield l.strip()
+        uuids = uuids_iter()
         log.info("Loading UUIDs list from file: %s", uuids_list_filepath)
-        d_iter = descriptor_index.get_many_descriptors(uuids_iter())
+        if max_descriptors:
+            uuids = list(uuids)
+            if max_descriptors < len(uuids):
+                log.info("Subsampling UUIDs (old count=%d, new count=%d)",
+                         len(uuids), max_descriptors)
+                uuids = random.sample(uuids, max_descriptors)
+        d_iter = descriptor_index.get_many_descriptors(uuids)
     else:
+        d_length = len(descriptor_index)
         log.info("Using UUIDs from loaded DescriptorIndex (count=%d)",
-                 len(descriptor_index))
-        d_iter = descriptor_index
+                 d_length)
+        if max_descriptors and max_descriptors < d_length:
+            log.info("Subsampling loaded DescriptorIndex (new count=%d)",
+                     max_descriptors)
+            d_iter = subsample(descriptor_index, max_descriptors, d_length)
+        else:
+            d_iter = descriptor_index
 
     log.info("Fitting ITQ model")
     functor.fit(d_iter)


### PR DESCRIPTION
This PR adds the ability to limit memory usage ITQ training. The current implementation modifies the `train_itq.py` tool to have an option `max_descriptors` that, when set and if necessary, sub-samples the available descriptors to the desired amount.

@mattdawkins: Is this suitable for approaching the problem you were seeing?

This is marked as WIP mainly because I need to perform some basic testing for obvious errors.

I'll also note that there may be some other opportunities to save memory (namely by `del`'ing `descriptors` in `ItqFunctor.fit` after its last use; see below), but this seems like good functionality to have anyway.
https://github.com/Kitware/SMQTK/blob/ea94e3bb6498e9afd93cc9e5cc8d8edb575c8058/python/smqtk/algorithms/nn_index/lsh/functors/itq.py#L330