### PR TITLE
Add ability to limit ITQ training memory usage

### DIFF
--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -5,6 +5,11 @@ SMQTK Pending Release Notes
 Updates / New Features
 ----------------------
 
+Scripts
+    - `train_itq`
+        - Added an optional configuration property
+          ``max_descriptors``.  The descriptors used to train the ITQ
+          model are a random sample of the available descriptors.
 
 Fixes
 -----

--- a/python/smqtk/bin/train_itq.py
+++ b/python/smqtk/bin/train_itq.py
@@ -9,10 +9,18 @@ The ``uuids_list_filepath`` configuration property is optional and should
 be used to specify a sub-set of descriptors in the configured index to
 train on. This only works if the stored descriptors' UUID is a type of
 string.
+
+The ``max_descriptors'' configuration property is optional and can be
+used to cap the number of descriptors used to train the model.  If
+more descriptors are available than requested, they are randomly
+subsampled.
 """
 
 import logging
 import os.path
+
+import numpy
+from six.moves import zip
 
 from smqtk.algorithms.nn_index.lsh.functors.itq import ItqFunctor
 from smqtk.representation import (
@@ -32,6 +40,7 @@ def default_config():
         "itq_config": ItqFunctor.get_default_config(),
         "uuids_list_filepath": None,
         "descriptor_index": plugin.make_config(get_descriptor_index_impls()),
+        "max_descriptors": None,
     }
 
 
@@ -45,6 +54,7 @@ def main():
     log = logging.getLogger(__name__)
 
     uuids_list_filepath = config['uuids_list_filepath']
+    max_descriptors = config['max_descriptors']
 
     log.info("Initializing ITQ functor")
     #: :type: smqtk.algorithms.nn_index.lsh.functors.itq.ItqFunctor
@@ -63,12 +73,26 @@ def main():
             with open(uuids_list_filepath) as f:
                 for l in f:
                     yield l.strip()
+        uuids = uuids_iter()
         log.info("Loading UUIDs list from file: %s", uuids_list_filepath)
-        d_iter = descriptor_index.get_many_descriptors(uuids_iter())
+        if max_descriptors:
+            uuids = list(uuids)
+            if max_descriptors < len(uuids):
+                log.info("Subsampling UUIDs (old count=%d, new count=%d)",
+                         len(uuids), max_descriptors)
+                uuids = numpy.random.choice(uuids, max_descriptors, replace=False)
+        d_iter = descriptor_index.get_many_descriptors(uuids)
     else:
+        d_length = len(descriptor_index)
         log.info("Using UUIDs from loaded DescriptorIndex (count=%d)",
-                 len(descriptor_index))
-        d_iter = descriptor_index
+                 d_length)
+        if max_descriptors and max_descriptors < d_length:
+            log.info("Subsampling loaded DescriptorIndex (new count=%d)",
+                     max_descriptors)
+            selected = numpy.random.permutation(numpy.arange(d_length) < max_descriptors)
+            d_iter = (d for d, s in zip(descriptor_index, selected) if s)
+        else:
+            d_iter = descriptor_index
 
     log.info("Fitting ITQ model")
     functor.fit(d_iter)


### PR DESCRIPTION
This is #370 again, but this time against master.

Copying from there:
> This PR adds the ability to limit memory usage [during] ITQ training. The current implementation modifies the `train_itq.py` tool to have an option `max_descriptors` that, when set and if necessary, sub-samples the available descriptors to the desired amount.
> 
> ... [snip] ...
> 
> I'll also note that there may be some other opportunities to save memory (namely by `del`'ing `descriptors` in `ItqFunctor.fit` after its last use; see below), but this seems like good functionality to have anyway.
> https://github.com/Kitware/SMQTK/blob/ea94e3bb6498e9afd93cc9e5cc8d8edb575c8058/python/smqtk/algorithms/nn_index/lsh/functors/itq.py#L330

I've combined the commits from #370 into one and added a release note.

@Purg, would you be interested in seeing tests for this, and if so, could you advise on how best to do so? My initial idea would involve a rather large amount of mocking.
