### PR TITLE
Update documentation python deps, remove mocking from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,10 +12,16 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
+import mock
 import os
 import shlex
-from mock import Mock as MagicMock
+import sys
+import warnings
+
+# Without an import of numpy, warnings are issued for numpy.dtype/ufunc size
+# changes.  numpy.__init__ adds filters for these warnings as they are not
+# useful (breaks in numpy ABI would be noticed by other means).
+import numpy
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -23,35 +29,10 @@ from mock import Mock as MagicMock
 sys.path.insert(0, os.path.abspath('../python'))
 # sys.path.insert(0, os.path.abspath('../bin'))
 
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-            return Mock()
-
-MOCK_MODULES = [
-    'imageio',
-    'matplotlib',
-    'matplotlib.pyplot',
-    'numpy',
-    'numpy.core',
-    'numpy.core.multiarray',
-    'numpy.matrixlib',
-    'numpy.matrixlib.defmatrix',
-    'PIL',
-    'PIL.Image',
-    'PIL.ImageEnhance',
-    'pymongo',
-    'scipy',
-    'scipy.stats',
-    'sklearn',
-    'sklearn.cluster',
-    'sklearn.cross_validation',
-    'sklearn.metrics',
-    'sklearn.neighbors',
-]
-
-
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+# Mock any modules that cannot be imported/used during the documentation
+# generation process.
+MOCK_MODULES = []
+sys.modules.update((mod_name, mock.Mock()) for mod_name in MOCK_MODULES)
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -60,11 +60,20 @@ Docker
 
         - Resolved an issue with upgrading pip for a newer version of matplotlib.
 
+Documentation
+
+    - Removed module mocking in sphinx ``conf.py`` as it has been shown to be
+      brittle to changes in the source code.  If we isolate and document a
+      use-case where the mocking becomes relevant again we can bring it back.
+
 Misc.
 
     - Update requests and flask package version in ``requirements.txt`` and
       ``devops/docker/smqtk_wrapper_python/requirements.txt`` files due to
       GitHub security alert.
+
+    - Updated package versions for packages in the ``requirements.docs.txt``
+      requirements file.
 
 Utilities
 

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,9 +1,9 @@
 # This is an implicit value, here for clarity
 --index-url https://pypi.python.org/simple/
 
-livereload==2.4.1
-sphinx==1.4.1
-sphinx-argparse==0.1.15
+livereload==2.6.0
+sphinx==1.8.4
+sphinx-argparse==0.2.5
 sphinx-prompt==1.0.0
-sphinx_rtd_theme==0.1.9
+sphinx_rtd_theme==0.4.3
 mock==2.0.0


### PR DESCRIPTION
The mocking that occurred in the ``docs/conf.py`` is brittle to changes in the python code when new sub-modules are imported and only adds the ability to build the documentation without an install of the SMQTK python package and its code dependencies.  This mocking was previously required because ReadTheDocs had previously only installed the requirements from the specificly configured requirements file.  Now, however, the whole SMQTK package is being installed via a ``python setup.py install --force`` command, thus installing all of SMQTK's core dependencies in the process of building the docs.