### PR TITLE
Add matplotlibrc to specify use of AGG backend explicitly

### DIFF
--- a/devops/docker/smqtk_iqr_playground/Dockerfile.cpu.df
+++ b/devops/docker/smqtk_iqr_playground/Dockerfile.cpu.df
@@ -55,6 +55,16 @@ RUN useradd -mr -s /bin/bash smqtk \
  && echo "smqtk ALL=(ALL:ALL) NOPASSWD:ALL" >>/etc/sudoers \
  && mkdir /images \
  && chown smqtk:smqtk /images
+
+
+# Configuration for Matplotlib to just use the Agg backend, not Tkinter
+COPY devops/docker/smqtk_iqr_playground/matplotlibrc \
+     /home/smqtk/.config/matplotlib/
+# Seems to need to be owned by the user for it to be considered "usable" by
+# matplotlib.
+RUN chown smqtk:smqtk -R /home/smqtk/.config
+
+
 USER smqtk
 WORKDIR /home/smqtk
 

--- a/devops/docker/smqtk_iqr_playground/Dockerfile.gpu-cuda8.0-cudnn6.df
+++ b/devops/docker/smqtk_iqr_playground/Dockerfile.gpu-cuda8.0-cudnn6.df
@@ -55,6 +55,16 @@ RUN useradd -mr -s /bin/bash smqtk \
  && echo "smqtk ALL=(ALL:ALL) NOPASSWD:ALL" >>/etc/sudoers \
  && mkdir /images \
  && chown smqtk:smqtk /images
+
+
+# Configuration for Matplotlib to just use the Agg backend, not Tkinter
+COPY devops/docker/smqtk_iqr_playground/matplotlibrc \
+     /home/smqtk/.config/matplotlib/
+# Seems to need to be owned by the user for it to be considered "usable" by
+# matplotlib.
+RUN chown smqtk:smqtk -R /home/smqtk/.config
+
+
 USER smqtk
 WORKDIR /home/smqtk
 

--- a/devops/docker/smqtk_iqr_playground/matplotlibrc
+++ b/devops/docker/smqtk_iqr_playground/matplotlibrc
@@ -1,0 +1,1 @@
+backend : Agg

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -8,3 +8,7 @@ Updates / New Features
 
 Fixes
 -----
+Docker
+* Fix issue with IQR playground image where matplotlib was attempting to use
+  the TkAgg backend by default by adding a ``matplotlibrc`` file to specify the
+  use of the ``Agg`` backend.


### PR DESCRIPTION
It seems to be the case that somewhere the TkAgg backend is being
selected as the default backend to be used even though there is no
python tk module required to use it. This causes an exception when
``matplotlib.pyplot`` is imported without intervention. We add here a
``.config/matplotlib/matplotlibrc`` file to explicitly request the use
of the Agg backend which does not cause exceptions.