### PR TITLE
Fix Py 2 to 3 encoding errors

### DIFF
--- a/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
+++ b/python/smqtk/algorithms/descriptor_generator/caffe_descriptor.py
@@ -181,11 +181,9 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
         #   - ``caffe.TEST`` indicates phase of either TRAIN or TEST
         self._log.debug("Initializing network")
         self._log.debug("Loading Caffe network from network/model configs")
-        self.network = caffe.Net(self.network_prototxt.write_temp(),
+        self.network = caffe.Net(self.network_prototxt,
                                  caffe.TEST,
-                                 weights=self.network_model.write_temp())
-        self.network_prototxt.clean_temp()
-        self.network_model.clean_temp()
+                                 weights=self.network_model)
         # Assuming the network has a 'data' layer and notion of data shape
         self.net_data_shape = self.network.blobs[self.data_layer].data.shape
         self._log.debug("Network data shape: %s", self.net_data_shape)
@@ -201,7 +199,7 @@ class CaffeDescriptorGenerator (DescriptorGenerator):
         if self.image_mean is not None:
             self._log.debug("Loading image mean (reducing to single pixel "
                             "mean)")
-            image_mean_bytes = self.image_mean.get_bytes()
+            image_mean_bytes = open(self.image_mean, "rb").read()
             try:
                 a = numpy.load(io.BytesIO(image_mean_bytes))
                 self._log.info("Loaded image mean from numpy bytes")

--- a/python/smqtk/web/search_app/modules/file_upload/FileUploadMod.py
+++ b/python/smqtk/web/search_app/modules/file_upload/FileUploadMod.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import tempfile
 
+from six import BytesIO
 from six.moves import cStringIO as StringIO
 
 from smqtk.utils import SmqtkObject
@@ -82,7 +83,7 @@ class FileUploadMod (SmqtkObject, flask.Blueprint):
                 # - Need to explicitly copy the buffered data as the file object
                 #   closes between chunk messages.
                 self._file_chunks.setdefault(fid, {})[current_chunk] \
-                    = StringIO(chunk_data.read())
+                    = BytesIO(chunk_data.read())
                 message = "Uploaded chunk #%d of %d for file '%s'" \
                     % (current_chunk, total_chunks, filename)
 


### PR DESCRIPTION
This merges changes made to path encodings in Caffe descriptor generator and fixed error during file upload. 