### PR TITLE
Fix readthedocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx-prompt',
     'sphinxarg.ext',
-    'nbsphinx',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/readthedocs-reqs.txt
+++ b/docs/readthedocs-reqs.txt
@@ -1,11 +1,13 @@
+# Base SMQTK requirements: ReadTheDocs installs the package.
+-r ../requirements.txt
+
+# Some of these deps are installed by ReadTheDocs implicitly so they are
+# "duplicate" here. However, listing them here is useful for a local
+# documentation build. Not pinning versions to allow
 sphinx
 sphinx_rtd_theme
-sphinx-argparse
-sphinx-prompt
-flask
-flask-login
-flask-basicauth
-requests
 mock
-nbsphinx
-ipykernel
+
+# SMQTK specific documentation depedencies
+sphinx-argparse==0.2.5
+sphinx-prompt==1.3.0


### PR DESCRIPTION
Recent branch broke readthedocs build due to a requirements mismatch when smqtk is locally installed during the build.