### PR TITLE
Fix errors by pinning downgraded transitive deps

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -11,7 +11,7 @@ Flask-login==0.5.0
 Flask-Cors==3.0.9
 imageio==2.8.0
 jinja2==2.11.3
-jsmin==2.2.2
+jsmin==3.0.1
 matplotlib==3.2.1
 numpy==1.18.4
 Pillow==8.4.0
@@ -19,3 +19,8 @@ pymongo==3.10.1
 requests==2.23.0
 scikit-learn==0.23.1
 scipy==1.4.1
+
+# Transitive deps that need downgrading relative to latest versions
+itsdangerous==2.0.1
+MarkupSafe==2.0.1
+werkzeug==2.0.3


### PR DESCRIPTION
Recent updates to dependency packages removed some required aspects by
pinned main deps.